### PR TITLE
Define a content provider for storing products data

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -2,3 +2,4 @@
 /shelf/
 /workspace.xml
 /compiler.xml
+/deploymentTargetDropDown.xml

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,10 +10,14 @@ android {
         targetSdk 32
         versionCode 1
         versionName "1.0"
+        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 }
 
 dependencies {
     // Material Components library. Contains modular and customizable Material Design UI components.
-    implementation 'com.google.android.material:material:1.6.1'
+    implementation "com.google.android.material:material:1.6.1"
+
+    // AndroidX Rules library. Needed for ProviderTestRule.
+    androidTestImplementation "androidx.test:rules:1.4.0"
 }

--- a/app/src/androidTest/java/com/davidread/clothescatalog/database/ProductProviderTest.java
+++ b/app/src/androidTest/java/com/davidread/clothescatalog/database/ProductProviderTest.java
@@ -1,0 +1,165 @@
+package com.davidread.clothescatalog.database;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+import android.content.ContentResolver;
+import android.content.ContentValues;
+import android.database.Cursor;
+import android.net.Uri;
+
+import androidx.test.rule.provider.ProviderTestRule;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * This class tests the correctness of {@link ProductProvider}.
+ */
+public class ProductProviderTest {
+
+    /**
+     * To access the functions of {@link ProductProvider}.
+     */
+    private ContentResolver contentResolver;
+
+    /**
+     * To mock {@link #contentResolver}.
+     */
+    @Rule
+    public ProviderTestRule providerTestRule =
+            new ProviderTestRule.Builder(ProductProvider.class, ProductContract.CONTENT_AUTHORITY)
+                    .build();
+
+    /**
+     * Callback invoked before each test. It initializes {@link #contentResolver}.
+     */
+    @Before
+    public void setUp() {
+        contentResolver = providerTestRule.getResolver();
+    }
+
+    /**
+     * Verify that when a valid {@link ContentValues} is passed into
+     * {@link ProductProvider#insert(Uri, ContentValues)}, it returns not {@code null}.
+     */
+    @Test
+    public void insert_ValidValues_ReturnsNotNull() {
+
+        ContentValues values = new ContentValues();
+        values.put(ProductContract.ProductEntry.COLUMN_NAME, "Red T-Shirt");
+        values.put(ProductContract.ProductEntry.COLUMN_PRICE, 1000);
+        values.put(ProductContract.ProductEntry.COLUMN_QUANTITY, 10);
+        values.put(ProductContract.ProductEntry.COLUMN_SUPPLIER, "Garment District");
+        values.put(ProductContract.ProductEntry.COLUMN_PICTURE, new byte[]{0, 1, 2, 3});
+
+        Uri insertUri = contentResolver.insert(ProductContract.ProductEntry.CONTENT_URI, values);
+
+        assertNotNull(insertUri);
+    }
+
+    /**
+     * Verify that when an invalid {@link ContentValues} is passed into
+     * {@link ProductProvider#insert(Uri, ContentValues)}, it returns {@code null}.
+     */
+    @Test
+    public void insert_InvalidValues_ReturnsNull() {
+
+        // Verify that a row with invalid amount of attributes cannot be inserted.
+        ContentValues values = new ContentValues();
+        values.put(ProductContract.ProductEntry.COLUMN_NAME, "Blue T-Shirt");
+
+        Uri insertUri = contentResolver.insert(ProductContract.ProductEntry.CONTENT_URI, values);
+
+        assertNull(insertUri);
+
+        // Verify that a row with an invalid price cannot be inserted.
+        ContentValues values1 = new ContentValues();
+        values.put(ProductContract.ProductEntry.COLUMN_NAME, "Yellow T-Shirt");
+        values.put(ProductContract.ProductEntry.COLUMN_PRICE, -23);
+        values.put(ProductContract.ProductEntry.COLUMN_QUANTITY, 55);
+        values.put(ProductContract.ProductEntry.COLUMN_SUPPLIER, "Bed Bath and Beyond");
+        values.put(ProductContract.ProductEntry.COLUMN_PICTURE, new byte[]{4, 5, 6, 7});
+
+        Uri insertUri1 = contentResolver.insert(ProductContract.ProductEntry.CONTENT_URI, values1);
+
+        assertNull(insertUri1);
+    }
+
+    /**
+     * Verify that when {@link ProductProvider#query(Uri, String[], String, String[], String)}
+     * queries all rows, it returns not {@code null}.
+     */
+    @Test
+    public void query_AllRows_ReturnsNotNull() {
+
+        Cursor cursor = contentResolver.query(
+                ProductContract.ProductEntry.CONTENT_URI,
+                null,
+                null,
+                null,
+                null
+        );
+
+        assertNotNull(cursor);
+    }
+
+    /**
+     * Verify that when {@link ProductProvider#update(Uri, ContentValues, String, String[])} updates
+     * all rows with valid {@link ContentValues}, it returns a non-error int.
+     */
+    @Test
+    public void update_ValidValues_ReturnsNotError() {
+
+        ContentValues values = new ContentValues();
+        values.put(ProductContract.ProductEntry.COLUMN_PICTURE, new byte[]{8, 9, 10, 11});
+
+        int countRowsUpdated = contentResolver.update(
+                ProductContract.ProductEntry.CONTENT_URI,
+                values,
+                null,
+                null
+        );
+
+        assertNotEquals(-1, countRowsUpdated);
+    }
+
+    /**
+     * Verify that when {@link ProductProvider#update(Uri, ContentValues, String, String[])} updates
+     * all rows with an invalid {@link ContentValues}, it returns an error int.
+     */
+    @Test
+    public void update_InvalidValues_ReturnsError() {
+
+        ContentValues values = new ContentValues();
+        values.put(ProductContract.ProductEntry.COLUMN_PRICE, -616);
+
+        int countRowsUpdated = contentResolver.update(
+                ProductContract.ProductEntry.CONTENT_URI,
+                values,
+                null,
+                null
+        );
+
+        assertEquals(-1, countRowsUpdated);
+    }
+
+    /**
+     * Verifies that when {@link ProductProvider#delete(Uri, String, String[])} deletes all rows, it
+     * returns a non-error int.
+     */
+    @Test
+    public void delete_AllRows_ReturnNotError() {
+
+        int countRowsDeleted = contentResolver.delete(
+                ProductContract.ProductEntry.CONTENT_URI,
+                null,
+                null
+        );
+
+        assertNotEquals(-1, countRowsDeleted);
+    }
+}

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -23,6 +23,11 @@
             </intent-filter>
         </activity>
 
+        <provider
+            android:name=".database.ProductProvider"
+            android:authorities="com.davidread.clothescatalog"
+            android:exported="false" />
+
     </application>
 
 </manifest>

--- a/app/src/main/java/com/davidread/clothescatalog/database/ProductContract.java
+++ b/app/src/main/java/com/davidread/clothescatalog/database/ProductContract.java
@@ -1,0 +1,64 @@
+package com.davidread.clothescatalog.database;
+
+import android.content.ContentResolver;
+import android.net.Uri;
+import android.provider.BaseColumns;
+
+/**
+ * A class that defines constants to help work with content URIs, column names, and other features
+ * of the content provider.
+ */
+public final class ProductContract {
+
+    /**
+     * Unique identifier for the content provider.
+     */
+    public static final String CONTENT_AUTHORITY = "com.davidread.clothescatalog";
+
+    /**
+     * Base content URI to refer to data in the content provider.
+     */
+    public static final Uri BASE_CONTENT_URI = Uri.parse("content://" + CONTENT_AUTHORITY);
+
+    /**
+     * Path to append to {@link #BASE_CONTENT_URI} to refer to the products table.
+     */
+    public static final String PATH_PRODUCTS = "products";
+
+    private ProductContract() {
+        // Private constructor prevents accidental instantiation of this class.
+    }
+
+    /**
+     * A class that defines constants to help work with data in the products table.
+     */
+    public static class ProductEntry implements BaseColumns {
+
+        /**
+         * Content URI to refer to data in the products table.
+         */
+        public static final Uri CONTENT_URI = Uri.withAppendedPath(BASE_CONTENT_URI, PATH_PRODUCTS);
+
+        /**
+         * MIME type of a single piece of data in the products table.
+         */
+        public static final String CONTENT_ITEM_TYPE = ContentResolver.CURSOR_ITEM_BASE_TYPE + "/" + CONTENT_AUTHORITY + "/" + PATH_PRODUCTS;
+
+        /**
+         * MIME type of a list of data in the products table.
+         */
+        public static final String CONTENT_LIST_TYPE = ContentResolver.CURSOR_DIR_BASE_TYPE + "/" + CONTENT_AUTHORITY + "/" + PATH_PRODUCTS;
+
+        /**
+         * Table name of the products table.
+         */
+        public static final String TABLE_NAME = "products";
+
+        // Column names of the products table.
+        public static final String COLUMN_NAME = "name";
+        public static final String COLUMN_PRICE = "price";
+        public static final String COLUMN_QUANTITY = "quantity";
+        public static final String COLUMN_SUPPLIER = "supplier";
+        public static final String COLUMN_PICTURE = "picture";
+    }
+}

--- a/app/src/main/java/com/davidread/clothescatalog/database/ProductDbHelper.java
+++ b/app/src/main/java/com/davidread/clothescatalog/database/ProductDbHelper.java
@@ -1,0 +1,65 @@
+package com.davidread.clothescatalog.database;
+
+import android.content.Context;
+import android.database.sqlite.SQLiteDatabase;
+import android.database.sqlite.SQLiteOpenHelper;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+/**
+ * A helper class for the SQLite database that stores the products table. It helps with database
+ * creation and version management.
+ */
+public class ProductDbHelper extends SQLiteOpenHelper {
+
+    /**
+     * File name for the database.
+     */
+    private static final String DB_NAME = "products.db";
+
+    /**
+     * Version for the database schema. Is constant since the schema will not be upgraded.
+     */
+    private static final int DB_VERSION = 1;
+
+
+    /**
+     * Constructs a new {@link ProductDbHelper}.
+     *
+     * @param context For the superclass.
+     */
+    public ProductDbHelper(@Nullable Context context) {
+        super(context, DB_NAME, null, DB_VERSION);
+    }
+
+    /**
+     * Callback invoked when the database is created for the first time. It initializes the database
+     * by creating a new products table.
+     *
+     * @param db The database being created.
+     */
+    @Override
+    public void onCreate(@NonNull SQLiteDatabase db) {
+        final String SQL_CREATE_PRODUCTS_TABLE = "CREATE TABLE " + ProductContract.ProductEntry.TABLE_NAME + " ("
+                + ProductContract.ProductEntry._ID + " INTEGER PRIMARY KEY AUTOINCREMENT, "
+                + ProductContract.ProductEntry.COLUMN_NAME + " TEXT NOT NULL, "
+                + ProductContract.ProductEntry.COLUMN_PRICE + " INTEGER NOT NULL DEFAULT 0, "
+                + ProductContract.ProductEntry.COLUMN_QUANTITY + " INTEGER NOT NULL DEFAULT 0, "
+                + ProductContract.ProductEntry.COLUMN_SUPPLIER + " TEXT NOT NULL, "
+                + ProductContract.ProductEntry.COLUMN_PICTURE + " BLOB NOT NULL);";
+        db.execSQL(SQL_CREATE_PRODUCTS_TABLE);
+    }
+
+    /**
+     * Callback invoked when the database schema is upgraded. It does nothing, since the schema will
+     * not be upgraded.
+     *
+     * @param db         The database being upgraded.
+     * @param oldVersion The old database version.
+     * @param newVersion The new database version.
+     */
+    @Override
+    public void onUpgrade(@NonNull SQLiteDatabase db, int oldVersion, int newVersion) {
+    }
+}

--- a/app/src/main/java/com/davidread/clothescatalog/database/ProductProvider.java
+++ b/app/src/main/java/com/davidread/clothescatalog/database/ProductProvider.java
@@ -1,0 +1,359 @@
+package com.davidread.clothescatalog.database;
+
+import android.content.ContentProvider;
+import android.content.ContentUris;
+import android.content.ContentValues;
+import android.content.UriMatcher;
+import android.database.Cursor;
+import android.database.sqlite.SQLiteDatabase;
+import android.net.Uri;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+/**
+ * A class that defines a {@link ContentProvider} for products data. Data is provided to
+ * applications through implementing the {@link android.content.ContentResolver} interface.
+ */
+public class ProductProvider extends ContentProvider {
+
+    /**
+     * URI matcher code for a content URI that refers to all products.
+     */
+    private static final int URI_CODE_ALL_PRODUCTS = 100;
+
+    /**
+     * URI matcher code for a content URI that refers to a single product.
+     */
+    private static final int URI_CODE_SINGLE_PRODUCT = 101;
+
+    /**
+     * Matches a content URI to a URI matcher code.
+     */
+    private static final UriMatcher uriMatcher = new UriMatcher(UriMatcher.NO_MATCH);
+
+    // Static initialization of {@link #uriMatcher}.
+    static {
+        uriMatcher.addURI(
+                ProductContract.CONTENT_AUTHORITY,
+                ProductContract.PATH_PRODUCTS, URI_CODE_ALL_PRODUCTS
+        );
+        uriMatcher.addURI(
+                ProductContract.CONTENT_AUTHORITY,
+                ProductContract.PATH_PRODUCTS + "/#", URI_CODE_SINGLE_PRODUCT
+        );
+    }
+
+    /**
+     * Gets SQLite database references.
+     */
+    private ProductDbHelper productDbHelper;
+
+    /**
+     * Callback invoked on this content provider's startup. It initializes {@link #productDbHelper}.
+     *
+     * @return True if the provider was successfully loaded, false otherwise.
+     */
+    @Override
+    public boolean onCreate() {
+        productDbHelper = new ProductDbHelper(getContext());
+        return true;
+    }
+
+    /**
+     * Returns the MIME type of the data stored in this content provider that the given content URI
+     * refers to.
+     *
+     * @param uri The content URI to query.
+     * @return The MIME type of the data. Returns {@code null} if the content URI does not refer to
+     * data stored in this content provider or if it just corresponds to data with no MIME type.
+     */
+    @Nullable
+    @Override
+    public String getType(@NonNull Uri uri) {
+        int match = uriMatcher.match(uri);
+        switch (match) {
+            case URI_CODE_ALL_PRODUCTS:
+                return ProductContract.ProductEntry.CONTENT_LIST_TYPE;
+            case URI_CODE_SINGLE_PRODUCT:
+                return ProductContract.ProductEntry.CONTENT_ITEM_TYPE;
+            default:
+                return null;
+        }
+    }
+
+    /**
+     * Inserts a new product into this content provider. Registered observers will be notified of
+     * the insertion.
+     *
+     * @param uri    Content URI of the insertion request.
+     * @param values A set of column name/value pairs to add to the database.
+     * @return The content URI for the newly inserted item. Is {@code null} if the insert request
+     * fails.
+     */
+    @Nullable
+    @Override
+    public Uri insert(@NonNull Uri uri, @NonNull ContentValues values) {
+
+        // Return null if ContentValues are invalid.
+        if (values.size() != 5 || !hasValidContentValues(values)) {
+            return null;
+        }
+
+        // Perform insert operation.
+        SQLiteDatabase db = productDbHelper.getWritableDatabase();
+        long insertId;
+        int match = uriMatcher.match(uri);
+        switch (match) {
+            case URI_CODE_ALL_PRODUCTS:
+                insertId = db.insert(
+                        ProductContract.ProductEntry.TABLE_NAME,
+                        null,
+                        values
+                );
+                break;
+            default:
+                insertId = -1;
+        }
+
+        // Return null if the insertion operation failed.
+        if (insertId == -1) {
+            return null;
+        }
+
+        // Notify listeners of insertion.
+        getContext().getContentResolver().notifyChange(uri, null);
+
+        return ContentUris.withAppendedId(uri, insertId);
+    }
+
+    /**
+     * Query products from this content provider. The return {@link Cursor} is registered to listen
+     * for changes in the content provider.
+     *
+     * @param uri           Content URI of the query request.
+     * @param projection    List of columns to put into the {@link Cursor}. If {@code null} then all
+     *                      columns are included.
+     * @param selection     A selection criteria to apply when filtering rows. If {@code null} then
+     *                      all rows are included.
+     * @param selectionArgs You may include ?s in selection, which will be replaced by the values
+     *                      from selectionArgs, in order that they appear in the selection. The
+     *                      values will be bound as {@link String}s.
+     * @param sortOrder     How the rows in the cursor should be sorted. If {@code null} then the
+     *                      content provider default sort order is used.
+     * @return A {@link Cursor} containing product data according to the query request. If
+     * {@code null} then the query request failed.
+     */
+    @Nullable
+    @Override
+    public Cursor query(@NonNull Uri uri, @Nullable String[] projection, @Nullable String selection,
+                        @Nullable String[] selectionArgs, @Nullable String sortOrder) {
+
+        // Perform query operation.
+        Cursor cursor;
+        SQLiteDatabase db = productDbHelper.getReadableDatabase();
+        int match = uriMatcher.match(uri);
+        switch (match) {
+            case URI_CODE_ALL_PRODUCTS:
+                cursor = db.query(
+                        ProductContract.ProductEntry.TABLE_NAME,
+                        projection,
+                        selection,
+                        selectionArgs,
+                        null,
+                        null,
+                        sortOrder
+                );
+                break;
+            case URI_CODE_SINGLE_PRODUCT:
+                selection = ProductContract.ProductEntry._ID + "=?";
+                selectionArgs = new String[]{String.valueOf(ContentUris.parseId(uri))};
+                cursor = db.query(
+                        ProductContract.ProductEntry.TABLE_NAME,
+                        projection,
+                        selection,
+                        selectionArgs,
+                        null,
+                        null,
+                        sortOrder
+                );
+                break;
+            default:
+                cursor = null;
+        }
+
+        // Setup listener that will keep this Cursor and this content provider's data in sync.
+        if (cursor != null) {
+            cursor.setNotificationUri(getContext().getContentResolver(), uri);
+        }
+
+        return cursor;
+    }
+
+    /**
+     * Update products in this content provider. Registered observers will be notified of the
+     * update.
+     *
+     * @param uri           Content URI of the update request.
+     * @param values        A set of column name/value pairs to update in the database.
+     * @param selection     A selection criteria to apply when filtering rows. If {@code null} then
+     *                      all rows are included.
+     * @param selectionArgs You may include ?s in selection, which will be replaced by the values
+     *                      from selectionArgs, in order that they appear in the selection. The
+     *                      values will be bound as {@link String}s.
+     * @return The number of rows updated. Is {@code -1} if the update request failed.
+     */
+    @Override
+    public int update(@NonNull Uri uri, @NonNull ContentValues values, @Nullable String selection,
+                      @Nullable String[] selectionArgs) {
+
+        // Return 0 if ContentValues is empty.
+        if (values.size() == 0) {
+            return 0;
+        }
+
+        // Return -1 if ContentValues are invalid.
+        if (!hasValidContentValues(values)) {
+            return -1;
+        }
+
+        // Perform update operation.
+        int countRowsUpdated;
+        SQLiteDatabase db = productDbHelper.getWritableDatabase();
+        int match = uriMatcher.match(uri);
+        switch (match) {
+            case URI_CODE_ALL_PRODUCTS:
+                countRowsUpdated = db.update(
+                        ProductContract.ProductEntry.TABLE_NAME,
+                        values,
+                        selection,
+                        selectionArgs
+                );
+                break;
+            case URI_CODE_SINGLE_PRODUCT:
+                selection = ProductContract.ProductEntry._ID + "=?";
+                selectionArgs = new String[]{String.valueOf(ContentUris.parseId(uri))};
+                countRowsUpdated = db.update(
+                        ProductContract.ProductEntry.TABLE_NAME,
+                        values,
+                        selection,
+                        selectionArgs
+                );
+                break;
+            default:
+                countRowsUpdated = -1;
+        }
+
+        // Notify listeners of update.
+        if (countRowsUpdated > 0) {
+            getContext().getContentResolver().notifyChange(uri, null);
+        }
+
+        return countRowsUpdated;
+    }
+
+    /**
+     * Delete products from this content provider. Registered observers will be notified of this
+     * deletion.
+     *
+     * @param uri           Content URI of the delete request.
+     * @param selection     A selection criteria to apply when filtering rows. If {@code null} then
+     *                      all rows are included.
+     * @param selectionArgs You may include ?s in selection, which will be replaced by the values
+     *                      from selectionArgs, in order that they appear in the selection. The
+     *                      values will be bound as {@link String}s.
+     * @return The number of rows deleted. Is {@code -1} if the delete request failed.
+     */
+    @Override
+    public int delete(@NonNull Uri uri, @Nullable String selection,
+                      @Nullable String[] selectionArgs) {
+
+        // Perform the delete operation.
+        int countRowsDeleted;
+        SQLiteDatabase db = productDbHelper.getWritableDatabase();
+        int match = uriMatcher.match(uri);
+        switch (match) {
+            case URI_CODE_ALL_PRODUCTS:
+                countRowsDeleted = db.delete(
+                        ProductContract.ProductEntry.TABLE_NAME,
+                        selection,
+                        selectionArgs
+                );
+                break;
+            case URI_CODE_SINGLE_PRODUCT:
+                selection = ProductContract.ProductEntry._ID + "=?";
+                selectionArgs = new String[]{String.valueOf(ContentUris.parseId(uri))};
+                countRowsDeleted = db.delete(
+                        ProductContract.ProductEntry.TABLE_NAME,
+                        selection,
+                        selectionArgs
+                );
+                break;
+            default:
+                countRowsDeleted = -1;
+        }
+
+        // Notify listeners of delete.
+        if (countRowsDeleted > 0) {
+            getContext().getContentResolver().notifyChange(uri, null);
+        }
+
+        return countRowsDeleted;
+    }
+
+    /**
+     * Returns whether a {@link ContentValues} has valid data that may be stored in this content
+     * provider.
+     *
+     * @param values {@link ContentValues} to query.
+     * @return True if the {@link ContentValues} are valid.
+     */
+    private boolean hasValidContentValues(@NonNull ContentValues values) {
+
+        // Name column must be a nonempty String.
+        if (values.containsKey(ProductContract.ProductEntry.COLUMN_NAME)) {
+            Object name = values.get(ProductContract.ProductEntry.COLUMN_NAME);
+            if (!(name instanceof String)
+                    || ((String) name).isEmpty()) {
+                return false;
+            }
+        }
+
+        // Price column must be a non-negative Integer.
+        if (values.containsKey(ProductContract.ProductEntry.COLUMN_PRICE)) {
+            Object price = values.get(ProductContract.ProductEntry.COLUMN_PRICE);
+            if (!(price instanceof Integer)
+                    || ((Integer) price) < 0) {
+                return false;
+            }
+        }
+
+        // Quantity column must be a non-negative Integer.
+        if (values.containsKey(ProductContract.ProductEntry.COLUMN_QUANTITY)) {
+            Object quantity = values.get(ProductContract.ProductEntry.COLUMN_QUANTITY);
+            if (!(quantity instanceof Integer)
+                    || ((Integer) quantity) < 0) {
+                return false;
+            }
+        }
+
+        // Supplier column must be a nonempty String.
+        if (values.containsKey(ProductContract.ProductEntry.COLUMN_SUPPLIER)) {
+            Object supplier = values.get(ProductContract.ProductEntry.COLUMN_SUPPLIER);
+            if (!(supplier instanceof String)
+                    || ((String) supplier).isEmpty()) {
+                return false;
+            }
+        }
+
+        // Picture column must be a byte array.
+        if (values.containsKey(ProductContract.ProductEntry.COLUMN_PICTURE)) {
+            Object picture = values.get(ProductContract.ProductEntry.COLUMN_PICTURE);
+            if (!(picture instanceof byte[])) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}


### PR DESCRIPTION
Changelog:
- Define ```ProductContract.java```. Is a class that defines constants to help work with content URIs, column names, and other features of the content provider.
- Define ```ProductDbHelper.java```. Is a helper class for interacting with the SQLite database that stores products data.
- Define ```ProductProvider.java```. Is a content provider for interacting with products data. It acts as a layer between ```ProductDbHelper.java``` and the ```ContentResolver``` subclass that will request to perform CRUD operations on products data. The layer enforces data validation on the requests.
- Define ```ProductProviderTest.java```. Is an Android test class that verifies the correctness of ```ProductProvider.java```.