### PR TITLE
Restrict negative quantities from being set in InventoryActivity

### DIFF
--- a/app/src/main/java/com/davidread/clothescatalog/InventoryActivity.java
+++ b/app/src/main/java/com/davidread/clothescatalog/InventoryActivity.java
@@ -203,6 +203,11 @@ public class InventoryActivity extends AppCompatActivity implements
      */
     @Override
     public void onDecrementButtonClick(long id, int quantity) {
+        // Do not allow decrements below 0.
+        if (quantity <= 0) {
+            return;
+        }
+
         // Perform update.
         Uri uri = ContentUris.withAppendedId(ProductContract.ProductEntry.CONTENT_URI, id);
         ContentValues values = new ContentValues();


### PR DESCRIPTION
# Changelog
- Restrict negative quantities from being set in ```InventoryActivity.java::onDecrementButtonClick()```.