### PR TITLE
Show delete confirmation dialogs before deleting products in InventoryActivity and DetailActivity

### DIFF
--- a/app/src/main/java/com/davidread/clothescatalog/view/DetailActivity.java
+++ b/app/src/main/java/com/davidread/clothescatalog/view/DetailActivity.java
@@ -260,22 +260,25 @@ public class DetailActivity extends AppCompatActivity implements
      */
     private void onDeleteProductButtonClick() {
         AlertDialog dialog = new AlertDialog.Builder(this)
-                .setMessage(R.string.delete_confirmation_dialog_message)
+                .setMessage(R.string.delete_product_confirmation_dialog_message)
                 .setPositiveButton(
-                        R.string.delete_confirmation_dialog_positive_label,
-                        this::onDeleteProductConfirmationPositiveButtonClick
+                        R.string.generic_delete_confirmation_dialog_positive_label,
+                        this::onDeleteProductConfirmationDialogPositiveButtonClick
                 )
-                .setNegativeButton(R.string.delete_confirmation_dialog_negative_label, null)
+                .setNegativeButton(R.string.generic_delete_confirmation_dialog_negative_label, null)
                 .create();
         dialog.show();
     }
 
     /**
-     * Invoked when the positive button of the delete product confirmation dialog ic clicked. It
+     * Invoked when the positive button of the delete product confirmation dialog is clicked. It
      * deletes the product corresponding with this activity. If the deletion operation fails, it
      * shows an error snackbar.
      */
-    private void onDeleteProductConfirmationPositiveButtonClick(DialogInterface dialog, int which) {
+    private void onDeleteProductConfirmationDialogPositiveButtonClick(
+            DialogInterface dialog,
+            int which
+    ) {
         int countRowsDeleted = getContentResolver().delete(selectedProductUri, null, null);
         if (countRowsDeleted == -1) {
             // Deletion failed.

--- a/app/src/main/java/com/davidread/clothescatalog/view/DetailActivity.java
+++ b/app/src/main/java/com/davidread/clothescatalog/view/DetailActivity.java
@@ -1,6 +1,7 @@
 package com.davidread.clothescatalog.view;
 
 import android.content.ContentValues;
+import android.content.DialogInterface;
 import android.content.Intent;
 import android.database.Cursor;
 import android.net.Uri;
@@ -14,6 +15,7 @@ import android.widget.Button;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.StringRes;
+import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.widget.TooltipCompat;
 import androidx.coordinatorlayout.widget.CoordinatorLayout;
@@ -253,11 +255,27 @@ public class DetailActivity extends AppCompatActivity implements
     }
 
     /**
-     * Invoked when the delete product button in the action bar is clicked. It deletes the product
-     * corresponding with this activity. If the deletion operation fails, it shows an error
-     * snackbar.
+     * Invoked when the delete product button in the action bar is clicked. It shows a delete
+     * product confirmation dialog.
      */
     private void onDeleteProductButtonClick() {
+        AlertDialog dialog = new AlertDialog.Builder(this)
+                .setMessage(R.string.delete_confirmation_dialog_message)
+                .setPositiveButton(
+                        R.string.delete_confirmation_dialog_positive_label,
+                        this::onDeleteProductConfirmationPositiveButtonClick
+                )
+                .setNegativeButton(R.string.delete_confirmation_dialog_negative_label, null)
+                .create();
+        dialog.show();
+    }
+
+    /**
+     * Invoked when the positive button of the delete product confirmation dialog ic clicked. It
+     * deletes the product corresponding with this activity. If the deletion operation fails, it
+     * shows an error snackbar.
+     */
+    private void onDeleteProductConfirmationPositiveButtonClick(DialogInterface dialog, int which) {
         int countRowsDeleted = getContentResolver().delete(selectedProductUri, null, null);
         if (countRowsDeleted == -1) {
             // Deletion failed.

--- a/app/src/main/java/com/davidread/clothescatalog/view/InventoryActivity.java
+++ b/app/src/main/java/com/davidread/clothescatalog/view/InventoryActivity.java
@@ -3,6 +3,7 @@ package com.davidread.clothescatalog.view;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.StringRes;
+import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.widget.TooltipCompat;
 import androidx.coordinatorlayout.widget.CoordinatorLayout;
@@ -14,6 +15,7 @@ import androidx.recyclerview.widget.RecyclerView;
 
 import android.content.ContentUris;
 import android.content.ContentValues;
+import android.content.DialogInterface;
 import android.content.Intent;
 import android.database.Cursor;
 import android.net.Uri;
@@ -189,11 +191,30 @@ public class InventoryActivity extends AppCompatActivity implements
     }
 
     /**
-     * Invoked when the delete all products button in the action bar is clicked. It deletes all
-     * products from the product provider. If the deletion operation fails, it shows an error
-     * snackbar.
+     * Invoked when the delete all products button in the action bar is clicked. It shows a delete
+     * all products confirmation dialog.
      */
     private void onDeleteAllProductsClick() {
+        AlertDialog dialog = new AlertDialog.Builder(this)
+                .setMessage(R.string.delete_all_products_confirmation_dialog_message)
+                .setPositiveButton(
+                        R.string.generic_delete_confirmation_dialog_positive_label,
+                        this::onDeleteAllProductsConfirmationDialogPositiveButtonClick
+                )
+                .setNegativeButton(R.string.generic_delete_confirmation_dialog_negative_label, null)
+                .create();
+        dialog.show();
+    }
+
+    /**
+     * Invoked when the positive button of the delete all products confirmation dialog is clicked.
+     * It deletes all products from the product provider. If the deletion operation fails, it shows
+     * an error snackbar.
+     */
+    private void onDeleteAllProductsConfirmationDialogPositiveButtonClick(
+            DialogInterface dialog,
+            int which
+    ) {
         int countRowsDeleted = getContentResolver().delete(
                 ProductContract.ProductEntry.CONTENT_URI,
                 null,

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -49,8 +49,9 @@
     <string name="number_invalid_error_message">Enter a value between 1 and 9 digits</string>
 
     <!-- Dialog strings. -->
-    <string name="delete_confirmation_dialog_message">Delete this product?</string>
-    <string name="delete_confirmation_dialog_positive_label">Delete</string>
-    <string name="delete_confirmation_dialog_negative_label">Cancel</string>
+    <string name="delete_all_products_confirmation_dialog_message">Delete all products?</string>
+    <string name="delete_product_confirmation_dialog_message">Delete this product?</string>
+    <string name="generic_delete_confirmation_dialog_positive_label">Delete</string>
+    <string name="generic_delete_confirmation_dialog_negative_label">Cancel</string>
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -48,4 +48,9 @@
     <string name="text_invalid_error_message">Enter a value between 1 and 250 characters</string>
     <string name="number_invalid_error_message">Enter a value between 1 and 9 digits</string>
 
+    <!-- Dialog strings. -->
+    <string name="delete_confirmation_dialog_message">Delete this product?</string>
+    <string name="delete_confirmation_dialog_positive_label">Delete</string>
+    <string name="delete_confirmation_dialog_negative_label">Cancel</string>
+
 </resources>


### PR DESCRIPTION
# Changelog
- Show confirmation dialog when deleting all products in ```InventoryActivity```.
- Show confirmation dialog when deleting a product in ```DetailActivity```.

# Screenshots
- ![Screenshot_20220918_015836](https://user-images.githubusercontent.com/49120229/190888067-2ae4318d-d4b5-43e2-a472-0416b248c449.png)
- ![Screenshot_20220918_015841](https://user-images.githubusercontent.com/49120229/190888068-c9674070-e941-4b17-9862-8ce9ccd5c2e6.png)
- ![Screenshot_20220918_015851](https://user-images.githubusercontent.com/49120229/190888070-c8b96220-f7b7-4f28-a68c-0fd202919149.png)
- ![Screenshot_20220918_015856](https://user-images.githubusercontent.com/49120229/190888071-775220e4-29c7-42b5-9b89-fcca9c43ab94.png)