### PR TITLE
Add Take New Photo feature to DetailActivity

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -3,11 +3,11 @@ plugins {
 }
 
 android {
-    compileSdk 32
+    compileSdk 33
     defaultConfig {
         applicationId "com.davidread.clothescatalog"
         minSdk 24
-        targetSdk 32
+        targetSdk 33
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
@@ -17,6 +17,10 @@ android {
 dependencies {
     // Material Components library. Contains modular and customizable Material Design UI components.
     implementation "com.google.android.material:material:1.6.1"
+
+    // AndroidX Activity and Fragment library. Needed for ActivityResultLauncher and related APIs.
+    implementation "androidx.activity:activity:1.6.0"
+    implementation "androidx.fragment:fragment:1.5.3"
 
     // AndroidX Rules library. Needed for ProviderTestRule.
     androidTestImplementation "androidx.test:rules:1.4.0"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,6 +3,16 @@
     xmlns:tools="http://schemas.android.com/tools"
     package="com.davidread.clothescatalog">
 
+    <uses-feature
+        android:name="android.hardware.camera"
+        android:required="true" />
+
+    <queries>
+        <intent>
+            <action android:name="android.media.action.IMAGE_CAPTURE" />
+        </intent>
+    </queries>
+
     <application
         android:allowBackup="false"
         android:dataExtractionRules="@xml/data_extraction_rules"
@@ -33,8 +43,18 @@
 
         <provider
             android:name=".database.ProductProvider"
-            android:authorities="com.davidread.clothescatalog"
+            android:authorities="${applicationId}"
             android:exported="false" />
+
+        <provider
+            android:name="androidx.core.content.FileProvider"
+            android:authorities="${applicationId}.fileprovider"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/file_paths" />
+        </provider>
 
     </application>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -13,6 +13,7 @@
     <string name="delete_product_failed_message">Failed to delete this product</string>
     <string name="delete_all_products_failed_message">Failed to delete all products</string>
     <string name="check_form_message">Check form for empty fields or errors</string>
+    <string name="take_picture_activity_failed_message">Failed to take photo</string>
 
     <!-- Action bar labels. -->
     <string name="action_add_dummy_product_label">Add a dummy product</string>

--- a/app/src/main/res/xml/file_paths.xml
+++ b/app/src/main/res/xml/file_paths.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths>
+    <files-path
+        name="internal"
+        path="." />
+</paths>


### PR DESCRIPTION
# Changelog
- Add AndroidX Activity and Fragment library dependencies for access to ```ActivityResultLauncher```.
- On "Take New Photo" dialog option click, use ```ActivityResultLauncher``` to handle the intent to use the device's camera to snap a photo for the product.
- On ```ActivityResultLauncher``` activity result, display the snapped photo in the UI.
- Persist the snapped photo for the product through clicks onto and off the ```DetailActivity```.

# Screenshots
- ![Screenshot_20221008_121314](https://user-images.githubusercontent.com/49120229/194717147-f3177e69-caf4-4797-9408-7e2941310d8d.png)
- ![Screenshot_20221008_121334](https://user-images.githubusercontent.com/49120229/194717148-d0effe8f-06fe-433d-98d1-b28b75af601d.png)
- ![Screenshot_20221008_121344](https://user-images.githubusercontent.com/49120229/194717150-76d2049a-f684-4733-9c7f-6b614bd605e9.png)