### PR TITLE
Add Select New Photo feature to DetailActivity

### DIFF
--- a/app/src/main/java/com/davidread/clothescatalog/view/DetailActivity.java
+++ b/app/src/main/java/com/davidread/clothescatalog/view/DetailActivity.java
@@ -569,12 +569,11 @@ public class DetailActivity extends AppCompatActivity implements
      * @param isSuccess Whether a picture was successfully snapped.
      */
     private void onTakePictureActivityResult(boolean isSuccess) {
-        if (isSuccess) {
-            picture = copyImageFileToByteArray(takePictureFile);
-            showImageInPhotoImageView(picture);
-        } else {
-            showSnackbar(R.string.take_picture_activity_failed_message);
+        if (!isSuccess) {
+            return;
         }
+        picture = copyImageFileToByteArray(takePictureFile);
+        showImageInPhotoImageView(picture);
     }
 
     /**
@@ -586,7 +585,6 @@ public class DetailActivity extends AppCompatActivity implements
      */
     private void onPickVisualMediaActivityResult(@Nullable Uri uri) {
         if (uri == null) {
-            showSnackbar(R.string.pick_visual_media_activity_failed_message);
             return;
         }
         File file = copyImageUriToFile(uri);

--- a/app/src/main/java/com/davidread/clothescatalog/view/DetailActivity.java
+++ b/app/src/main/java/com/davidread/clothescatalog/view/DetailActivity.java
@@ -10,13 +10,17 @@ import android.graphics.BitmapFactory;
 import android.net.Uri;
 import android.os.Bundle;
 import android.text.Editable;
+import android.util.Log;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.widget.Button;
 import android.widget.ImageView;
 
 import androidx.activity.result.ActivityResultLauncher;
+import androidx.activity.result.PickVisualMediaRequest;
 import androidx.activity.result.contract.ActivityResultContracts;
+import androidx.activity.result.contract.ActivityResultContracts.PickVisualMedia.VisualMediaType;
+import androidx.activity.result.contract.ActivityResultContracts.PickVisualMedia.ImageOnly;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.StringRes;
@@ -41,6 +45,10 @@ import com.google.android.material.textfield.TextInputLayout;
 
 import java.io.ByteArrayOutputStream;
 import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 
@@ -50,6 +58,11 @@ import java.util.Date;
  */
 public class DetailActivity extends AppCompatActivity implements
         LoaderManager.LoaderCallbacks<Cursor> {
+
+    /**
+     * Tag to use for logs in this class.
+     */
+    private static final String TAG = DetailActivity.class.getSimpleName();
 
     /**
      * Regular expressions that each text field should be matched with to be valid.
@@ -113,6 +126,11 @@ public class DetailActivity extends AppCompatActivity implements
     private File takePictureFile;
 
     /**
+     * Launches an activity to pick an image for the product.
+     */
+    private ActivityResultLauncher<PickVisualMediaRequest> pickVisualMediaActivityResultLauncher;
+
+    /**
      * Root view of the layout for animating the save product button when a snackbar appears.
      */
     private CoordinatorLayout detailCoordinatorLayout;
@@ -147,6 +165,11 @@ public class DetailActivity extends AppCompatActivity implements
         takePictureActivityResultLauncher = registerForActivityResult(
                 new ActivityResultContracts.TakePicture(),
                 this::onTakePictureActivityResult
+        );
+
+        pickVisualMediaActivityResultLauncher = registerForActivityResult(
+                new ActivityResultContracts.PickVisualMedia(),
+                this::onPickVisualMediaActivityResult
         );
 
         detailCoordinatorLayout = findViewById(R.id.detail_coordinator_layout);
@@ -418,15 +441,16 @@ public class DetailActivity extends AppCompatActivity implements
     }
 
     /**
-     * Invoked when the select new photo button is clicked. It does nothing for now.
+     * Invoked when the select new photo button is clicked. It launches an intent to the device's
+     * gallery to pick a photo. It returns a URI to the selected photo in
+     * {@link #onPickVisualMediaActivityResult(Uri)} when done.
      */
     private void onSelectNewPhotoButtonClick() {
-        // TODO: Launch intent to select a new photo with some Gallery API and put it in the ImageView.
-        Snackbar.make(
-                detailCoordinatorLayout,
-                "Launch intent to select a new photo with some Gallery API and put it in the ImageView",
-                BaseTransientBottomBar.LENGTH_SHORT
-        ).show();
+        VisualMediaType mediaType = (VisualMediaType) ImageOnly.INSTANCE;
+        PickVisualMediaRequest request = new PickVisualMediaRequest.Builder()
+                .setMediaType(mediaType)
+                .build();
+        pickVisualMediaActivityResultLauncher.launch(request);
     }
 
     /**
@@ -541,18 +565,33 @@ public class DetailActivity extends AppCompatActivity implements
      * Invoked when the activity started by {@link #takePictureActivityResultLauncher} finishes and
      * control returns to this activity. If the previous activity successfully snapped a picture,
      * it populates the image view with the picture.
+     *
+     * @param isSuccess Whether a picture was successfully snapped.
      */
     private void onTakePictureActivityResult(boolean isSuccess) {
         if (isSuccess) {
-            String takePictureFilePath = takePictureFile.getAbsolutePath();
-            Bitmap takePictureBitmap = BitmapFactory.decodeFile(takePictureFilePath);
-            ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-            takePictureBitmap.compress(Bitmap.CompressFormat.JPEG, 100, outputStream);
-            picture = outputStream.toByteArray();
+            picture = copyImageFileToByteArray(takePictureFile);
             showImageInPhotoImageView(picture);
         } else {
             showSnackbar(R.string.take_picture_activity_failed_message);
         }
+    }
+
+    /**
+     * Invoked when the activity started by {@link #pickVisualMediaActivityResultLauncher} finishes
+     * and control returns to this activity. If the previous activity successfully picked a picture,
+     * it populates the image view with the picture.
+     *
+     * @param uri URI of the picked picture.
+     */
+    private void onPickVisualMediaActivityResult(@Nullable Uri uri) {
+        if (uri == null) {
+            showSnackbar(R.string.pick_visual_media_activity_failed_message);
+            return;
+        }
+        File file = copyImageUriToFile(uri);
+        picture = copyImageFileToByteArray(file);
+        showImageInPhotoImageView(picture);
     }
 
     /**
@@ -623,6 +662,46 @@ public class DetailActivity extends AppCompatActivity implements
         String fileName = String.format(FILE_NAME, timestamp);
         File fileDir = getFilesDir();
         return new File(fileDir, fileName);
+    }
+
+    /**
+     * Copies the data at a given URI onto a new file in this app's private directory.
+     *
+     * @param uri URI to copy from.
+     * @return A new {@link File} instance.
+     */
+    @NonNull
+    private File copyImageUriToFile(@NonNull Uri uri) {
+        File file = createFile();
+        try {
+            InputStream inputStream = getContentResolver().openInputStream(uri);
+            OutputStream outputStream = new FileOutputStream(file);
+            byte[] buffer = new byte[1024];
+            int length;
+            while ((length = inputStream.read(buffer)) > 0) {
+                outputStream.write(buffer, 0, length);
+            }
+            inputStream.close();
+            outputStream.close();
+        } catch (IOException e) {
+            Log.e(TAG, e.toString());
+        }
+        return file;
+    }
+
+    /**
+     * Copies a file containing a picture to a {@code byte[]}.
+     *
+     * @param file  File to copy from.
+     * @return {@code byte[]} equivalent of the picture.
+     */
+    @NonNull
+    private byte[] copyImageFileToByteArray(@NonNull File file) {
+        String filePath = file.getAbsolutePath();
+        Bitmap bitmap = BitmapFactory.decodeFile(filePath);
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        bitmap.compress(Bitmap.CompressFormat.JPEG, 100, outputStream);
+        return outputStream.toByteArray();
     }
 
     /**

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -14,6 +14,7 @@
     <string name="delete_all_products_failed_message">Failed to delete all products</string>
     <string name="check_form_message">Check form for empty fields or errors</string>
     <string name="take_picture_activity_failed_message">Failed to take photo</string>
+    <string name="pick_visual_media_activity_failed_message">Failed to select a photo</string>
 
     <!-- Action bar labels. -->
     <string name="action_add_dummy_product_label">Add a dummy product</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -13,8 +13,6 @@
     <string name="delete_product_failed_message">Failed to delete this product</string>
     <string name="delete_all_products_failed_message">Failed to delete all products</string>
     <string name="check_form_message">Check form for empty fields or errors</string>
-    <string name="take_picture_activity_failed_message">Failed to take photo</string>
-    <string name="pick_visual_media_activity_failed_message">Failed to select a photo</string>
 
     <!-- Action bar labels. -->
     <string name="action_add_dummy_product_label">Add a dummy product</string>


### PR DESCRIPTION
# Changelog
- On Select New Photo dialog option click, use ```ActivityResultLauncher``` to handle the intent to choose a photo from the device's storage for the product.
- On ```ActivityResultLauncher``` activity result, display the chosen photo in the UI.
- Persist the chosen photo for the product through clicks onto and off the ```DetailActivity```.
- Remove error ```Snackbar```s from showing for ```ActivityResultLauncher``` activity results. Because, these were being shown for neutral activity results too, and this is not expected behavior.

# Screenshots
- ![Screenshot_20221008_220227](https://user-images.githubusercontent.com/49120229/194734254-8f9287d1-9b54-49ca-9761-abf01dfe1d8a.png)
- ![Screenshot_20221008_220344](https://user-images.githubusercontent.com/49120229/194734255-b173670d-40ca-42b7-b14c-4509a6d84a72.png)
- ![Screenshot_20221008_220357](https://user-images.githubusercontent.com/49120229/194734256-99f391b9-1d25-4620-9cac-0ab4dbda7203.png)