### PR TITLE
Add supplier contact info columns to ProductProvider and supplier contact info fields to DetailActivity

### DIFF
--- a/app/src/main/java/com/davidread/clothescatalog/database/ProductContract.java
+++ b/app/src/main/java/com/davidread/clothescatalog/database/ProductContract.java
@@ -59,6 +59,8 @@ public final class ProductContract {
         public static final String COLUMN_PRICE = "price";
         public static final String COLUMN_QUANTITY = "quantity";
         public static final String COLUMN_SUPPLIER = "supplier";
+        public static final String COLUMN_SUPPLIER_PHONE_NUMBER = "supplier_phone_number";
+        public static final String COLUMN_SUPPLIER_EMAIL = "supplier_email";
         public static final String COLUMN_PICTURE = "picture";
     }
 }

--- a/app/src/main/java/com/davidread/clothescatalog/database/ProductDbHelper.java
+++ b/app/src/main/java/com/davidread/clothescatalog/database/ProductDbHelper.java
@@ -47,7 +47,7 @@ public class ProductDbHelper extends SQLiteOpenHelper {
                 + ProductContract.ProductEntry.COLUMN_PRICE + " INTEGER NOT NULL DEFAULT 0, "
                 + ProductContract.ProductEntry.COLUMN_QUANTITY + " INTEGER NOT NULL DEFAULT 0, "
                 + ProductContract.ProductEntry.COLUMN_SUPPLIER + " TEXT NOT NULL, "
-                + ProductContract.ProductEntry.COLUMN_SUPPLIER_PHONE_NUMBER + " INTEGER NOT NULL DEFAULT 0, "
+                + ProductContract.ProductEntry.COLUMN_SUPPLIER_PHONE_NUMBER + " TEXT NOT NULL, "
                 + ProductContract.ProductEntry.COLUMN_SUPPLIER_EMAIL + " TEXT NOT NULL, "
                 + ProductContract.ProductEntry.COLUMN_PICTURE + " BLOB);";
         db.execSQL(SQL_CREATE_PRODUCTS_TABLE);

--- a/app/src/main/java/com/davidread/clothescatalog/database/ProductDbHelper.java
+++ b/app/src/main/java/com/davidread/clothescatalog/database/ProductDbHelper.java
@@ -47,6 +47,8 @@ public class ProductDbHelper extends SQLiteOpenHelper {
                 + ProductContract.ProductEntry.COLUMN_PRICE + " INTEGER NOT NULL DEFAULT 0, "
                 + ProductContract.ProductEntry.COLUMN_QUANTITY + " INTEGER NOT NULL DEFAULT 0, "
                 + ProductContract.ProductEntry.COLUMN_SUPPLIER + " TEXT NOT NULL, "
+                + ProductContract.ProductEntry.COLUMN_SUPPLIER_PHONE_NUMBER + " INTEGER NOT NULL DEFAULT 0, "
+                + ProductContract.ProductEntry.COLUMN_SUPPLIER_EMAIL + " TEXT NOT NULL, "
                 + ProductContract.ProductEntry.COLUMN_PICTURE + " BLOB);";
         db.execSQL(SQL_CREATE_PRODUCTS_TABLE);
     }

--- a/app/src/main/java/com/davidread/clothescatalog/database/ProductProvider.java
+++ b/app/src/main/java/com/davidread/clothescatalog/database/ProductProvider.java
@@ -96,7 +96,7 @@ public class ProductProvider extends ContentProvider {
     public Uri insert(@NonNull Uri uri, @NonNull ContentValues values) {
 
         // Return null if ContentValues are invalid.
-        if (values.size() != 5 || !hasValidContentValues(values)) {
+        if (values.size() != 7 || !hasValidContentValues(values)) {
             return null;
         }
 
@@ -342,6 +342,26 @@ public class ProductProvider extends ContentProvider {
             Object supplier = values.get(ProductContract.ProductEntry.COLUMN_SUPPLIER);
             if (!(supplier instanceof String)
                     || ((String) supplier).isEmpty()) {
+                return false;
+            }
+        }
+
+        // Supplier phone number must be a non-negative Integer.
+        if (values.containsKey(ProductContract.ProductEntry.COLUMN_SUPPLIER_PHONE_NUMBER)) {
+            Object supplierPhoneNumber = values.get(
+                    ProductContract.ProductEntry.COLUMN_SUPPLIER_PHONE_NUMBER
+            );
+            if (!(supplierPhoneNumber instanceof Integer)
+                    || ((Integer) supplierPhoneNumber) < 0) {
+                return false;
+            }
+        }
+
+        // Supplier email must be a nonempty String.
+        if (values.containsKey(ProductContract.ProductEntry.COLUMN_SUPPLIER_EMAIL)) {
+            Object supplierEmail = values.get(ProductContract.ProductEntry.COLUMN_SUPPLIER_EMAIL);
+            if (!(supplierEmail instanceof String)
+                    || ((String) supplierEmail).isEmpty()) {
                 return false;
             }
         }

--- a/app/src/main/java/com/davidread/clothescatalog/database/ProductProvider.java
+++ b/app/src/main/java/com/davidread/clothescatalog/database/ProductProvider.java
@@ -346,13 +346,13 @@ public class ProductProvider extends ContentProvider {
             }
         }
 
-        // Supplier phone number must be a non-negative Integer.
+        // Supplier phone number must be a nonempty String.
         if (values.containsKey(ProductContract.ProductEntry.COLUMN_SUPPLIER_PHONE_NUMBER)) {
             Object supplierPhoneNumber = values.get(
                     ProductContract.ProductEntry.COLUMN_SUPPLIER_PHONE_NUMBER
             );
-            if (!(supplierPhoneNumber instanceof Integer)
-                    || ((Integer) supplierPhoneNumber) < 0) {
+            if (!(supplierPhoneNumber instanceof String)
+                    || ((String) supplierPhoneNumber).isEmpty()) {
                 return false;
             }
         }

--- a/app/src/main/java/com/davidread/clothescatalog/util/DummyConstants.java
+++ b/app/src/main/java/com/davidread/clothescatalog/util/DummyConstants.java
@@ -37,11 +37,11 @@ public final class DummyConstants {
     /**
      * Dummy supplier values.
      */
-    public static final String[] DUMMY_SUPPLIERS = {
-            "Grainger Industrial Supply",
-            "Hudson Wholesale Inc.",
-            "Regards Wholesale",
-            "Garment Center Supplier Association",
-            "eFashion Wholesale"
+    public static final String[][] DUMMY_SUPPLIERS = {
+            {"Grainger Industrial Supply", "603-413-4124", "support@gis.com"},
+            {"Hudson Wholesale Inc.", "605-475-6964", "order.more@hudsonwholesale.com"},
+            {"Regards Wholesale", "605-475-6958", "getmore@regards.com"},
+            {"Garment Center Supplier Association", "212-479-7990", "contactus@gcsa.com"},
+            {"eFashion Wholesale", "605-475-6959", "sales@efashion.com"}
     };
 }

--- a/app/src/main/java/com/davidread/clothescatalog/util/EmailTextWatcher.java
+++ b/app/src/main/java/com/davidread/clothescatalog/util/EmailTextWatcher.java
@@ -1,0 +1,68 @@
+package com.davidread.clothescatalog.util;
+
+import android.text.Editable;
+import android.text.TextWatcher;
+import android.util.Patterns;
+
+import androidx.annotation.NonNull;
+
+import com.google.android.material.textfield.TextInputLayout;
+
+/**
+ * A concrete implementation of {@link TextWatcher} that may be attached to a
+ * {@link com.google.android.material.textfield.TextInputEditText} to validate that contents
+ * contains an email address. If not, then an error message will be shown on the field.
+ */
+public class EmailTextWatcher implements TextWatcher {
+
+    /**
+     * Error message to show when there is no match.
+     */
+    private final String errorMessage;
+
+    /**
+     * {@link TextInputLayout} to set the error on.
+     */
+    private final TextInputLayout textInputLayout;
+
+    /**
+     * Constructs a new {@link EmailTextWatcher}.
+     *
+     * @param errorMessage    Error message to show when there is no match
+     * @param textInputLayout {@link TextInputLayout} to set the error on.
+     */
+    public EmailTextWatcher(@NonNull String errorMessage, @NonNull TextInputLayout textInputLayout) {
+        this.errorMessage = errorMessage;
+        this.textInputLayout = textInputLayout;
+    }
+
+    @Override
+    public void beforeTextChanged(CharSequence s, int start, int count, int after) {
+    }
+
+    /**
+     * Invoked each time the contents of
+     * {@link com.google.android.material.textfield.TextInputEditText} changes. It validates the
+     * contents and sets an error on {@link #textInputLayout} if there is no match. Otherwise, it
+     * removes the error on it.
+     *
+     * @param s      {@link CharSequence} contained within the
+     *               {@link com.google.android.material.textfield.TextInputEditText}.
+     */
+    @Override
+    public void onTextChanged(CharSequence s, int start, int before, int count) {
+        boolean match = Patterns.EMAIL_ADDRESS.matcher(s).matches();
+        if (match) {
+            // Matches valid email address.
+            textInputLayout.setError(null);
+            textInputLayout.setErrorEnabled(false);
+        } else {
+            // Does not match valid email address.
+            textInputLayout.setError(errorMessage);
+        }
+    }
+
+    @Override
+    public void afterTextChanged(Editable s) {
+    }
+}

--- a/app/src/main/java/com/davidread/clothescatalog/util/PhoneNumberTextWatcher.java
+++ b/app/src/main/java/com/davidread/clothescatalog/util/PhoneNumberTextWatcher.java
@@ -1,0 +1,68 @@
+package com.davidread.clothescatalog.util;
+
+import android.telephony.PhoneNumberUtils;
+import android.text.Editable;
+import android.text.TextWatcher;
+
+import androidx.annotation.NonNull;
+
+import com.google.android.material.textfield.TextInputLayout;
+
+/**
+ * A concrete implementation of {@link TextWatcher} that may be attached to a
+ * {@link com.google.android.material.textfield.TextInputEditText} to validate that contents
+ * contains a phone number. If not, then an error message will be shown on the field.
+ */
+public class PhoneNumberTextWatcher implements TextWatcher {
+
+    /**
+     * Error message to show when there is no match.
+     */
+    private final String errorMessage;
+
+    /**
+     * {@link TextInputLayout} to set the error on.
+     */
+    private final TextInputLayout textInputLayout;
+
+    /**
+     * Constructs a new {@link PhoneNumberTextWatcher}.
+     *
+     * @param errorMessage    Error message to show when there is no match
+     * @param textInputLayout {@link TextInputLayout} to set the error on.
+     */
+    public PhoneNumberTextWatcher(@NonNull String errorMessage, @NonNull TextInputLayout textInputLayout) {
+        this.errorMessage = errorMessage;
+        this.textInputLayout = textInputLayout;
+    }
+
+    @Override
+    public void beforeTextChanged(CharSequence s, int start, int count, int after) {
+    }
+
+    /**
+     * Invoked each time the contents of
+     * {@link com.google.android.material.textfield.TextInputEditText} changes. It validates the
+     * contents and sets an error on {@link #textInputLayout} if there is no match. Otherwise, it
+     * removes the error on it.
+     *
+     * @param s      {@link CharSequence} contained within the
+     *               {@link com.google.android.material.textfield.TextInputEditText}.
+     */
+    @Override
+    public void onTextChanged(CharSequence s, int start, int before, int count) {
+        boolean match = PhoneNumberUtils.isGlobalPhoneNumber(s.toString());
+        if (match) {
+            // Matches valid phone number.
+            textInputLayout.setError(null);
+            textInputLayout.setErrorEnabled(false);
+        } else {
+            // Does not match valid phone number.
+            textInputLayout.setError(errorMessage);
+        }
+    }
+
+    @Override
+    public void afterTextChanged(Editable s) {
+    }
+}

--- a/app/src/main/java/com/davidread/clothescatalog/view/InventoryActivity.java
+++ b/app/src/main/java/com/davidread/clothescatalog/view/InventoryActivity.java
@@ -300,9 +300,18 @@ public class InventoryActivity extends AppCompatActivity implements
         );
         values.put(ProductContract.ProductEntry.COLUMN_PRICE, random.nextInt(10000));
         values.put(ProductContract.ProductEntry.COLUMN_QUANTITY, random.nextInt(1000));
+        int supplierIndex = random.nextInt(DummyConstants.DUMMY_SUPPLIERS.length);
         values.put(
                 ProductContract.ProductEntry.COLUMN_SUPPLIER,
-                DummyConstants.DUMMY_SUPPLIERS[random.nextInt(DummyConstants.DUMMY_SUPPLIERS.length)]
+                DummyConstants.DUMMY_SUPPLIERS[supplierIndex][0]
+        );
+        values.put(
+                ProductContract.ProductEntry.COLUMN_SUPPLIER_PHONE_NUMBER,
+                DummyConstants.DUMMY_SUPPLIERS[supplierIndex][1]
+        );
+        values.put(
+                ProductContract.ProductEntry.COLUMN_SUPPLIER_EMAIL,
+                DummyConstants.DUMMY_SUPPLIERS[supplierIndex][2]
         );
         values.put(ProductContract.ProductEntry.COLUMN_PICTURE, (byte[]) null);
         return values;

--- a/app/src/main/res/drawable/ic_email.xml
+++ b/app/src/main/res/drawable/ic_email.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:tint="#000000"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M20,4L4,4c-1.1,0 -1.99,0.9 -1.99,2L2,18c0,1.1 0.9,2 2,2h16c1.1,0 2,-0.9 2,-2L22,6c0,-1.1 -0.9,-2 -2,-2zM20,8l-8,5 -8,-5L4,6l8,5 8,-5v2z" />
+</vector>

--- a/app/src/main/res/drawable/ic_phone.xml
+++ b/app/src/main/res/drawable/ic_phone.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:tint="#000000"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M6.62,10.79c1.44,2.83 3.76,5.14 6.59,6.59l2.2,-2.2c0.27,-0.27 0.67,-0.36 1.02,-0.24 1.12,0.37 2.33,0.57 3.57,0.57 0.55,0 1,0.45 1,1V20c0,0.55 -0.45,1 -1,1 -9.39,0 -17,-7.61 -17,-17 0,-0.55 0.45,-1 1,-1h3.5c0.55,0 1,0.45 1,1 0,1.25 0.2,2.45 0.57,3.57 0.11,0.35 0.03,0.74 -0.25,1.02l-2.2,2.2z" />
+</vector>

--- a/app/src/main/res/layout/activity_detail.xml
+++ b/app/src/main/res/layout/activity_detail.xml
@@ -148,6 +148,48 @@
 
             </com.google.android.material.textfield.TextInputLayout>
 
+            <!-- Supplier phone number field. -->
+            <com.google.android.material.textfield.TextInputLayout
+                android:id="@+id/supplier_phone_number_text_input_layout"
+                style="@style/TextInputLayoutStyle"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/detail_activity_views_vertical_margin"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/supplier_text_input_layout"
+                app:startIconDrawable="@drawable/ic_phone">
+
+                <com.google.android.material.textfield.TextInputEditText
+                    android:id="@+id/supplier_phone_number_text_input_edit_text"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:hint="@string/supplier_phone_number_hint"
+                    android:inputType="phone" />
+
+            </com.google.android.material.textfield.TextInputLayout>
+
+            <!-- Supplier email field. -->
+            <com.google.android.material.textfield.TextInputLayout
+                android:id="@+id/supplier_email_text_input_layout"
+                style="@style/TextInputLayoutStyle"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/detail_activity_views_vertical_margin"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/supplier_phone_number_text_input_layout"
+                app:startIconDrawable="@drawable/ic_email">
+
+                <com.google.android.material.textfield.TextInputEditText
+                    android:id="@+id/supplier_email_text_input_edit_text"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:hint="@string/supplier_email_hint"
+                    android:inputType="textEmailAddress" />
+
+            </com.google.android.material.textfield.TextInputLayout>
+
         </androidx.constraintlayout.widget.ConstraintLayout>
 
     </ScrollView>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -53,6 +53,8 @@
     <!-- EditText error messages. -->
     <string name="text_invalid_error_message">Enter a value between 1 and 250 characters</string>
     <string name="number_invalid_error_message">Enter a value between 1 and 9 digits</string>
+    <string name="phone_number_invalid_error_message">Enter a valid phone number</string>
+    <string name="email_invalid_error_message">Enter a valid email address</string>
 
     <!-- Dialog strings. -->
     <string name="delete_all_products_confirmation_dialog_message">Delete all products?</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -47,6 +47,8 @@
     <string name="price_hint">Price</string>
     <string name="quantity_hint">Quantity</string>
     <string name="supplier_hint">Supplier</string>
+    <string name="supplier_phone_number_hint">Supplier Phone Number</string>
+    <string name="supplier_email_hint">Supplier Email</string>
 
     <!-- EditText error messages. -->
     <string name="text_invalid_error_message">Enter a value between 1 and 250 characters</string>


### PR DESCRIPTION
# Changelog
- Add supplier contact info columns to ```ProductProvider```.
- Modify ```DetailActivity``` layout to have supplier contact info fields.
- Add text validation to supplier contact info fields and persist their values through clicks onto and off of ```DetailActivity```.
- Have add dummy product ```InventoryActivity``` feature add dummy supplier contact info to ```ProductProvider```.

# Screenshots
- ![Screenshot_20221009_140117](https://user-images.githubusercontent.com/49120229/194772456-72520755-9d43-4567-9c66-6d37cf045110.png)
- ![Screenshot_20221009_140230](https://user-images.githubusercontent.com/49120229/194772457-0b414134-0bfd-4a74-9fc4-677f8b4d5b67.png)
- ![Screenshot_20221009_140257](https://user-images.githubusercontent.com/49120229/194772458-8b5f9f9d-fc53-45dc-8a4d-0da3373ad568.png)