### PR TITLE
Add supplier contact info buttons in DetailActivity

### DIFF
--- a/app/src/main/res/layout/activity_detail.xml
+++ b/app/src/main/res/layout/activity_detail.xml
@@ -169,6 +169,17 @@
 
             </com.google.android.material.textfield.TextInputLayout>
 
+            <!-- Call supplier button. -->
+            <Button
+                android:id="@+id/call_supplier_button"
+                style="@style/SecondaryButtonStyle"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:contentDescription="@string/call_supplier_button_content_description"
+                android:text="@string/call_supplier_button_label"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/supplier_phone_number_text_input_layout" />
+
             <!-- Supplier email field. -->
             <com.google.android.material.textfield.TextInputLayout
                 android:id="@+id/supplier_email_text_input_layout"
@@ -178,7 +189,7 @@
                 android:layout_marginTop="@dimen/detail_activity_views_vertical_margin"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/supplier_phone_number_text_input_layout"
+                app:layout_constraintTop_toBottomOf="@id/call_supplier_button"
                 app:startIconDrawable="@drawable/ic_email">
 
                 <com.google.android.material.textfield.TextInputEditText
@@ -189,6 +200,17 @@
                     android:inputType="textEmailAddress" />
 
             </com.google.android.material.textfield.TextInputLayout>
+
+            <!-- Email supplier button. -->
+            <Button
+                android:id="@+id/email_supplier_button"
+                style="@style/SecondaryButtonStyle"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:contentDescription="@string/email_supplier_button_content_description"
+                android:text="@string/email_supplier_button_label"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/supplier_email_text_input_layout" />
 
         </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -36,6 +36,10 @@
     <string name="increment_quantity_button_label">+</string>
     <string name="increment_quantity_button_tooltip">Increment quantity</string>
     <string name="increment_quantity_button_content_description">Increment this product\s quantity</string>
+    <string name="call_supplier_button_label">Call supplier</string>
+    <string name="call_supplier_button_content_description">Call this product\s supplier</string>
+    <string name="email_supplier_button_label">Email supplier</string>
+    <string name="email_supplier_button_content_description">Email this product\s supplier</string>
     <string name="save_product_button_tooltip">Save product</string>
     <string name="save_product_button_content_description">Save and close this product</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -13,6 +13,8 @@
     <string name="delete_product_failed_message">Failed to delete this product</string>
     <string name="delete_all_products_failed_message">Failed to delete all products</string>
     <string name="check_form_message">Check form for empty fields or errors</string>
+    <string name="no_phone_app_message">Download a phone app to dial this call</string>
+    <string name="no_email_app_message">Download an email app to send this message</string>
 
     <!-- Action bar labels. -->
     <string name="action_add_dummy_product_label">Add a dummy product</string>
@@ -70,5 +72,9 @@
         <item>Remove photo</item>
         <item>Select new photo</item>
     </array>
+
+    <!-- Supplier email strings. -->
+    <string name="email_supplier_subject">Request for more \"%1$s\"</string>
+    <string name="email_supplier_message">Hello,\n\nI am requesting more of the product \"%1$s\" in the next shipment. We only have %2$d left in stock.\n\nSent from Clothes Catalog app.</string>
 
 </resources>


### PR DESCRIPTION
# Changelog
- Add Call Supplier button to ```DetailActivity```. Have it dial the phone number with the device's phone app in the Supplier Phone Number field on click.
- Add Email Supplier button to ```DetailActivity```. Have it draft an email with the device's email app on click.

# Screenshots
- ![Screenshot_20221011_175109](https://user-images.githubusercontent.com/49120229/195223721-a4bf0d1d-3b1e-4ba0-ae60-848bdef67420.png)
- ![Screenshot_20221011_175131](https://user-images.githubusercontent.com/49120229/195223724-c5acdc8d-f888-4000-af97-4222380008d9.png)
- ![Screenshot_20221011_175159](https://user-images.githubusercontent.com/49120229/195223725-b1efc5b4-80c0-45a5-8625-723144e63d5d.png)