### PR TITLE
Format prices in currency/decimal format app-wide.

### DIFF
--- a/app/src/main/java/com/davidread/clothescatalog/adapter/ProductCursorAdapter.java
+++ b/app/src/main/java/com/davidread/clothescatalog/adapter/ProductCursorAdapter.java
@@ -13,6 +13,7 @@ import androidx.recyclerview.widget.RecyclerView;
 
 import com.davidread.clothescatalog.R;
 import com.davidread.clothescatalog.database.ProductContract;
+import com.davidread.clothescatalog.database.ProductProviderUtils;
 
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
@@ -87,10 +88,9 @@ public class ProductCursorAdapter extends RecyclerView.Adapter<ProductCursorAdap
     public void onBindViewHolder(@NonNull ProductCursorAdapter.ProductViewHolder holder, int position) {
         cursor.moveToPosition(position);
         int nameColumnIndex = cursor.getColumnIndex(ProductContract.ProductEntry.COLUMN_NAME);
-        int priceColumnIndex = cursor.getColumnIndex(ProductContract.ProductEntry.COLUMN_PRICE);
         int quantityColumnIndex = cursor.getColumnIndex(ProductContract.ProductEntry.COLUMN_QUANTITY);
         String name = cursor.getString(nameColumnIndex);
-        String price = cursor.getString(priceColumnIndex);
+        String price = ProductProviderUtils.getCurrencyFormatPrice(cursor);
         String quantity = cursor.getString(quantityColumnIndex);
 
         holder.getNameTextView().setText(name);

--- a/app/src/main/java/com/davidread/clothescatalog/database/ProductProviderUtils.java
+++ b/app/src/main/java/com/davidread/clothescatalog/database/ProductProviderUtils.java
@@ -1,0 +1,77 @@
+package com.davidread.clothescatalog.database;
+
+import android.content.ContentValues;
+import android.database.Cursor;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import java.text.DecimalFormat;
+import java.text.NumberFormat;
+import java.util.Locale;
+
+public final class ProductProviderUtils {
+
+    private ProductProviderUtils() {
+        // Private constructor prevents accidental instantiation of this class.
+    }
+
+    /**
+     * Puts a price from the UI into the given content values to store in the product provider.
+     *
+     * @param values Content values to put the price in.
+     * @param price  Price directly from the UI.
+     */
+    public static void putPrice(@NonNull ContentValues values, double price) {
+        int intPrice = (int) (price * 100);
+        values.put(ProductContract.ProductEntry.COLUMN_PRICE, intPrice);
+    }
+
+    /**
+     * Returns a price string in decimal format to show in the UI from a cursor from the product
+     * provider. Returns {@code null} if no price is stored in the cursor.
+     *
+     * @param cursor Cursor already pointing at some row.
+     * @return Price string in decimal format or {@code null}.
+     */
+    @Nullable
+    public static String getDecimalFormatPrice(@NonNull Cursor cursor) {
+        double doublePrice = getDoublePrice(cursor);
+        DecimalFormat decimalFormat = new DecimalFormat("0.00");
+        return doublePrice != -1
+                ? decimalFormat.format(doublePrice)
+                : null;
+    }
+
+    /**
+     * Returns a price string in currency format to show in the UI from a cursor from the product
+     * provider. Returns {@code null} if no price is stored in the cursor.
+     *
+     * @param cursor Cursor already pointing at some row.
+     * @return Price string in currency format or {@code null}.
+     */
+    @Nullable
+    public static String getCurrencyFormatPrice(@NonNull Cursor cursor) {
+        double doublePrice = getDoublePrice(cursor);
+        NumberFormat numberFormat = NumberFormat.getCurrencyInstance(Locale.US);
+        return doublePrice != -1
+                ? numberFormat.format(doublePrice)
+                : null;
+    }
+
+    /**
+     * Returns a price double from a cursor from the product provider. Returns {@code -1} if no
+     * price is stored in the cursor.
+     *
+     * @param cursor Cursor already pointing at some row.
+     * @return Price double or {@code -1}.
+     */
+    private static double getDoublePrice(@NonNull Cursor cursor) {
+        int priceColumnIndex = cursor.getColumnIndex(ProductContract.ProductEntry.COLUMN_PRICE);
+        if (priceColumnIndex == -1) {
+            return -1;
+        }
+        int intPrice = cursor.getInt(priceColumnIndex);
+        return (double) intPrice * 0.01;
+    }
+}

--- a/app/src/main/java/com/davidread/clothescatalog/view/DetailActivity.java
+++ b/app/src/main/java/com/davidread/clothescatalog/view/DetailActivity.java
@@ -39,6 +39,7 @@ import androidx.loader.content.Loader;
 import com.davidread.clothescatalog.BuildConfig;
 import com.davidread.clothescatalog.R;
 import com.davidread.clothescatalog.database.ProductContract;
+import com.davidread.clothescatalog.database.ProductProviderUtils;
 import com.davidread.clothescatalog.util.EmailTextWatcher;
 import com.davidread.clothescatalog.util.PhoneNumberTextWatcher;
 import com.davidread.clothescatalog.util.RegexTextWatcher;
@@ -73,7 +74,7 @@ public class DetailActivity extends AppCompatActivity implements
      * Regular expressions that each text field should be matched with to be valid.
      */
     private static final String NAME_PATTERN = "^.{1,250}$";
-    private static final String PRICE_PATTERN = "^\\d{1,9}$";
+    private static final String PRICE_PATTERN = "^\\d{1,7}[.]\\d\\d$";
     private static final String QUANTITY_PATTERN = "^\\d{1,9}$";
     private static final String SUPPLIER_PATTERN = "^.{1,250}$";
 
@@ -212,13 +213,13 @@ public class DetailActivity extends AppCompatActivity implements
         TextInputLayout priceTextInputLayout = findViewById(R.id.price_text_input_layout);
         priceTextInputEditText.addTextChangedListener(new RegexTextWatcher(
                 PRICE_PATTERN,
-                getString(R.string.number_invalid_error_message),
+                getString(R.string.price_invalid_error_message),
                 priceTextInputLayout
         ));
         TextInputLayout quantityTextInputLayout = findViewById(R.id.quantity_text_input_layout);
         quantityTextInputEditText.addTextChangedListener(new RegexTextWatcher(
                 QUANTITY_PATTERN,
-                getString(R.string.number_invalid_error_message),
+                getString(R.string.quantity_invalid_error_message),
                 quantityTextInputLayout
         ));
         TextInputLayout supplierTextInputLayout = findViewById(R.id.supplier_text_input_layout);
@@ -356,7 +357,6 @@ public class DetailActivity extends AppCompatActivity implements
 
         int idColumnIndex = data.getColumnIndex(ProductContract.ProductEntry._ID);
         int nameColumnIndex = data.getColumnIndex(ProductContract.ProductEntry.COLUMN_NAME);
-        int priceColumnIndex = data.getColumnIndex(ProductContract.ProductEntry.COLUMN_PRICE);
         int quantityColumnIndex = data.getColumnIndex(ProductContract.ProductEntry.COLUMN_QUANTITY);
         int supplierColumnIndex = data.getColumnIndex(ProductContract.ProductEntry.COLUMN_SUPPLIER);
         int supplierPhoneNumberColumnIndex = data.getColumnIndex(
@@ -369,7 +369,7 @@ public class DetailActivity extends AppCompatActivity implements
 
         id = data.getInt(idColumnIndex);
         String name = data.getString(nameColumnIndex);
-        String price = data.getString(priceColumnIndex);
+        String price = ProductProviderUtils.getDecimalFormatPrice(data);
         String quantity = data.getString(quantityColumnIndex);
         String supplier = data.getString(supplierColumnIndex);
         String supplierPhoneNumber = data.getString(supplierPhoneNumberColumnIndex);
@@ -618,10 +618,10 @@ public class DetailActivity extends AppCompatActivity implements
                 NAME_PATTERN,
                 String.class
         );
-        Integer price = extractValueFromEditText(
+        Double price = extractValueFromEditText(
                 priceTextInputEditText,
                 PRICE_PATTERN,
-                Integer.class
+                Double.class
         );
         Integer quantity = extractValueFromEditText(
                 quantityTextInputEditText,
@@ -652,7 +652,7 @@ public class DetailActivity extends AppCompatActivity implements
 
         ContentValues values = new ContentValues();
         values.put(ProductContract.ProductEntry.COLUMN_NAME, name);
-        values.put(ProductContract.ProductEntry.COLUMN_PRICE, price);
+        ProductProviderUtils.putPrice(values, price);
         values.put(ProductContract.ProductEntry.COLUMN_QUANTITY, quantity);
         values.put(ProductContract.ProductEntry.COLUMN_SUPPLIER, supplier);
         values.put(ProductContract.ProductEntry.COLUMN_SUPPLIER_PHONE_NUMBER, supplierPhoneNumber);
@@ -737,8 +737,8 @@ public class DetailActivity extends AppCompatActivity implements
      *                    matching should be done.
      * @param returnClass Class type to convert the extracted value to. Accepts only {@link String}
      *                    and {@link Integer} so far.
-     * @param <T>         Class type to convert the extracted value to. Accepts only {@link String}
-     *                    and {@link Integer} so far.
+     * @param <T>         Class type to convert the extracted value to. Accepts only {@link String},
+     *                    {@link Integer}, and {@link Double} so far.
      * @return The value from the edit text. {@code null} if regular expression matching fails or
      * if some conversion error occurs.
      */
@@ -765,6 +765,14 @@ public class DetailActivity extends AppCompatActivity implements
                 // Return value as Integer.
                 int textInteger = Integer.parseInt(textString);
                 return returnClass.cast(textInteger);
+            } catch (NumberFormatException e) {
+                return null;
+            }
+        } else if (returnClass == Double.class) {
+            try {
+                // Return value as Double.
+                double textDouble = Double.parseDouble(textString);
+                return returnClass.cast(textDouble);
             } catch (NumberFormatException e) {
                 return null;
             }

--- a/app/src/main/res/layout/activity_detail.xml
+++ b/app/src/main/res/layout/activity_detail.xml
@@ -80,7 +80,7 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:hint="@string/price_hint"
-                    android:inputType="number" />
+                    android:inputType="numberDecimal" />
 
             </com.google.android.material.textfield.TextInputLayout>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -58,7 +58,8 @@
 
     <!-- EditText error messages. -->
     <string name="text_invalid_error_message">Enter a value between 1 and 250 characters</string>
-    <string name="number_invalid_error_message">Enter a value between 1 and 9 digits</string>
+    <string name="price_invalid_error_message">Enter a price between $0.00 and $9,999,999.99</string>
+    <string name="quantity_invalid_error_message">Enter a quantity between 0 and 999,999,999</string>
     <string name="phone_number_invalid_error_message">Enter a valid phone number</string>
     <string name="email_invalid_error_message">Enter a valid email address</string>
 


### PR DESCRIPTION
# Changelog
- Format price as a currency on ```InventoryActivity```.
- Format price as a decimal on ```DetailActivity```.
- Preserve price in ```ProductProvider``` using the same method, despite the fact that the price is being displayed as a floating point number in the UI.

# Screenshots
- ![Screenshot_20221013_184545](https://user-images.githubusercontent.com/49120229/195724611-2f1840d2-624e-48d6-8ecb-5c5f304ecf07.png)
- ![Screenshot_20221013_184606](https://user-images.githubusercontent.com/49120229/195724615-2db43ee5-9345-4057-b13b-7d17c9a4695e.png)
- ![Screenshot_20221013_184720](https://user-images.githubusercontent.com/49120229/195724618-af8bba52-6f64-48e3-b22a-c365fda0a873.png)