### PR TITLE
DetailActivity bugfix. Allow single decimal price to be entered in DetailActivity.

### DIFF
--- a/app/src/main/java/com/davidread/clothescatalog/view/DetailActivity.java
+++ b/app/src/main/java/com/davidread/clothescatalog/view/DetailActivity.java
@@ -74,7 +74,7 @@ public class DetailActivity extends AppCompatActivity implements
      * Regular expressions that each text field should be matched with to be valid.
      */
     private static final String NAME_PATTERN = "^.{1,250}$";
-    private static final String PRICE_PATTERN = "^\\d{1,7}[.]\\d\\d$";
+    private static final String PRICE_PATTERN = "^\\d{1,7}[.]\\d{1,2}$";
     private static final String QUANTITY_PATTERN = "^\\d{1,9}$";
     private static final String SUPPLIER_PATTERN = "^.{1,250}$";
 

--- a/app/src/main/java/com/davidread/clothescatalog/view/DetailActivity.java
+++ b/app/src/main/java/com/davidread/clothescatalog/view/DetailActivity.java
@@ -513,7 +513,7 @@ public class DetailActivity extends AppCompatActivity implements
     private void onDecrementQuantityButtonClick() {
         Integer quantity = extractValueFromEditText(
                 quantityTextInputEditText,
-                QUANTITY_PATTERN,
+                null,
                 Integer.class
         );
         if (quantity == null || quantity <= 0) {
@@ -527,16 +527,16 @@ public class DetailActivity extends AppCompatActivity implements
 
     /**
      * Invoked when the increment button is clicked. It increments the quantity of the value in
-     * {@link #quantityTextInputEditText} by 1.
+     * {@link #quantityTextInputEditText} by 1 without letting the quantity fall above 999,999,999.
      */
     private void onIncrementQuantityButtonClick() {
         Integer quantity = extractValueFromEditText(
                 quantityTextInputEditText,
-                QUANTITY_PATTERN,
+                null,
                 Integer.class
         );
-        if (quantity == null) {
-            // No quantity was in the text field.
+        if (quantity == null || quantity >= 999999999) {
+            // No quantity was in the text field or quantity cannot be incremented any further.
             return;
         }
         quantity++;


### PR DESCRIPTION
# Changelog
- Allow one decimal values to be entered for a product price in ```DetailActivity``` per Udacity rubric guidelines.

# Screenshots
- ![Screenshot_20221016_165518](https://user-images.githubusercontent.com/49120229/196057922-20a880ad-5084-43f6-a678-4cdaf90941e8.png)
- ![Screenshot_20221016_165541](https://user-images.githubusercontent.com/49120229/196057924-fea512cd-114e-4a2b-aa73-c9e86895daa0.png)