### PR TITLE
DetailActivity bugfix. Allow no decimal price to be entered in DetailActivity.

### DIFF
--- a/app/src/main/java/com/davidread/clothescatalog/view/DetailActivity.java
+++ b/app/src/main/java/com/davidread/clothescatalog/view/DetailActivity.java
@@ -74,7 +74,7 @@ public class DetailActivity extends AppCompatActivity implements
      * Regular expressions that each text field should be matched with to be valid.
      */
     private static final String NAME_PATTERN = "^.{1,250}$";
-    private static final String PRICE_PATTERN = "^\\d{1,7}[.]\\d\\d$";
+    private static final String PRICE_PATTERN = "^\\d{1,7}[.]\\d{1,2}$";
     private static final String QUANTITY_PATTERN = "^\\d{1,9}$";
     private static final String SUPPLIER_PATTERN = "^.{1,250}$";
 

--- a/app/src/main/java/com/davidread/clothescatalog/view/DetailActivity.java
+++ b/app/src/main/java/com/davidread/clothescatalog/view/DetailActivity.java
@@ -74,7 +74,7 @@ public class DetailActivity extends AppCompatActivity implements
      * Regular expressions that each text field should be matched with to be valid.
      */
     private static final String NAME_PATTERN = "^.{1,250}$";
-    private static final String PRICE_PATTERN = "^\\d{1,7}[.]\\d{1,2}$";
+    private static final String PRICE_PATTERN = "^\\d{1,7}(|[.]\\d{1,2})$";
     private static final String QUANTITY_PATTERN = "^\\d{1,9}$";
     private static final String SUPPLIER_PATTERN = "^.{1,250}$";
 


### PR DESCRIPTION
# Changelog
- Allow no decimal values to be entered for a product price in ```DetailActivity``` per Udacity rubric guidelines.

# Screenshots
- ![Screenshot_20221016_192152](https://user-images.githubusercontent.com/49120229/196063636-2063c3cc-2d3a-48d5-b9cd-2d727f49093b.png)
- ![Screenshot_20221016_192200](https://user-images.githubusercontent.com/49120229/196063637-9950a512-21aa-4f41-a0f7-b2a9a74111a0.png)