### PR TITLE
Fix SQLiteBlobTooBigException bug and too many onLoadFinished() call bug in DetailActivity

### DIFF
--- a/app/src/androidTest/java/com/davidread/clothescatalog/database/ProductProviderTest.java
+++ b/app/src/androidTest/java/com/davidread/clothescatalog/database/ProductProviderTest.java
@@ -54,7 +54,7 @@ public class ProductProviderTest {
         values.put(ProductContract.ProductEntry.COLUMN_PRICE, 1000);
         values.put(ProductContract.ProductEntry.COLUMN_QUANTITY, 10);
         values.put(ProductContract.ProductEntry.COLUMN_SUPPLIER, "Garment District");
-        values.put(ProductContract.ProductEntry.COLUMN_PICTURE, new byte[]{0, 1, 2, 3});
+        values.put(ProductContract.ProductEntry.COLUMN_PICTURE_PATH, new byte[]{0, 1, 2, 3});
 
         Uri insertUri = contentResolver.insert(ProductContract.ProductEntry.CONTENT_URI, values);
 
@@ -82,7 +82,7 @@ public class ProductProviderTest {
         values.put(ProductContract.ProductEntry.COLUMN_PRICE, -23);
         values.put(ProductContract.ProductEntry.COLUMN_QUANTITY, 55);
         values.put(ProductContract.ProductEntry.COLUMN_SUPPLIER, "Bed Bath and Beyond");
-        values.put(ProductContract.ProductEntry.COLUMN_PICTURE, new byte[]{4, 5, 6, 7});
+        values.put(ProductContract.ProductEntry.COLUMN_PICTURE_PATH, new byte[]{4, 5, 6, 7});
 
         Uri insertUri1 = contentResolver.insert(ProductContract.ProductEntry.CONTENT_URI, values1);
 
@@ -115,7 +115,7 @@ public class ProductProviderTest {
     public void update_ValidValues_ReturnsNotError() {
 
         ContentValues values = new ContentValues();
-        values.put(ProductContract.ProductEntry.COLUMN_PICTURE, new byte[]{8, 9, 10, 11});
+        values.put(ProductContract.ProductEntry.COLUMN_PICTURE_PATH, new byte[]{8, 9, 10, 11});
 
         int countRowsUpdated = contentResolver.update(
                 ProductContract.ProductEntry.CONTENT_URI,

--- a/app/src/main/java/com/davidread/clothescatalog/database/ProductContract.java
+++ b/app/src/main/java/com/davidread/clothescatalog/database/ProductContract.java
@@ -61,6 +61,6 @@ public final class ProductContract {
         public static final String COLUMN_SUPPLIER = "supplier";
         public static final String COLUMN_SUPPLIER_PHONE_NUMBER = "supplier_phone_number";
         public static final String COLUMN_SUPPLIER_EMAIL = "supplier_email";
-        public static final String COLUMN_PICTURE = "picture";
+        public static final String COLUMN_PICTURE_PATH = "picture_path";
     }
 }

--- a/app/src/main/java/com/davidread/clothescatalog/database/ProductDbHelper.java
+++ b/app/src/main/java/com/davidread/clothescatalog/database/ProductDbHelper.java
@@ -49,7 +49,7 @@ public class ProductDbHelper extends SQLiteOpenHelper {
                 + ProductContract.ProductEntry.COLUMN_SUPPLIER + " TEXT NOT NULL, "
                 + ProductContract.ProductEntry.COLUMN_SUPPLIER_PHONE_NUMBER + " TEXT NOT NULL, "
                 + ProductContract.ProductEntry.COLUMN_SUPPLIER_EMAIL + " TEXT NOT NULL, "
-                + ProductContract.ProductEntry.COLUMN_PICTURE + " BLOB);";
+                + ProductContract.ProductEntry.COLUMN_PICTURE_PATH + " TEXT);";
         db.execSQL(SQL_CREATE_PRODUCTS_TABLE);
     }
 

--- a/app/src/main/java/com/davidread/clothescatalog/database/ProductProvider.java
+++ b/app/src/main/java/com/davidread/clothescatalog/database/ProductProvider.java
@@ -366,10 +366,11 @@ public class ProductProvider extends ContentProvider {
             }
         }
 
-        // Picture column must be either null or a byte array.
-        if (values.containsKey(ProductContract.ProductEntry.COLUMN_PICTURE)) {
-            Object picture = values.get(ProductContract.ProductEntry.COLUMN_PICTURE);
-            if (picture != null && !(picture instanceof byte[])) {
+        // Picture path column must be null or a String.
+        if (values.containsKey(ProductContract.ProductEntry.COLUMN_PICTURE_PATH)) {
+            Object picturePath = values.get(ProductContract.ProductEntry.COLUMN_PICTURE_PATH);
+            if (picturePath != null
+                    && !(picturePath instanceof String)) {
                 return false;
             }
         }

--- a/app/src/main/java/com/davidread/clothescatalog/database/ProductProviderUtils.java
+++ b/app/src/main/java/com/davidread/clothescatalog/database/ProductProviderUtils.java
@@ -10,6 +10,10 @@ import java.text.DecimalFormat;
 import java.text.NumberFormat;
 import java.util.Locale;
 
+/**
+ * A class that provides util functions for accessing and modifying the price of a product in
+ * the product provider.
+ */
 public final class ProductProviderUtils {
 
     private ProductProviderUtils() {

--- a/app/src/main/java/com/davidread/clothescatalog/view/DetailActivity.java
+++ b/app/src/main/java/com/davidread/clothescatalog/view/DetailActivity.java
@@ -328,7 +328,7 @@ public class DetailActivity extends AppCompatActivity implements
                 ProductContract.ProductEntry.COLUMN_SUPPLIER,
                 ProductContract.ProductEntry.COLUMN_SUPPLIER_PHONE_NUMBER,
                 ProductContract.ProductEntry.COLUMN_SUPPLIER_EMAIL,
-                ProductContract.ProductEntry.COLUMN_PICTURE
+                ProductContract.ProductEntry.COLUMN_PICTURE_PATH
         };
         return new CursorLoader(
                 this,
@@ -365,7 +365,7 @@ public class DetailActivity extends AppCompatActivity implements
         int supplierEmailColumnIndex = data.getColumnIndex(
                 ProductContract.ProductEntry.COLUMN_SUPPLIER_EMAIL
         );
-        int pictureColumnIndex = data.getColumnIndex(ProductContract.ProductEntry.COLUMN_PICTURE);
+        int pictureColumnIndex = data.getColumnIndex(ProductContract.ProductEntry.COLUMN_PICTURE_PATH);
 
         id = data.getInt(idColumnIndex);
         String name = data.getString(nameColumnIndex);
@@ -657,7 +657,7 @@ public class DetailActivity extends AppCompatActivity implements
         values.put(ProductContract.ProductEntry.COLUMN_SUPPLIER, supplier);
         values.put(ProductContract.ProductEntry.COLUMN_SUPPLIER_PHONE_NUMBER, supplierPhoneNumber);
         values.put(ProductContract.ProductEntry.COLUMN_SUPPLIER_EMAIL, supplierEmail);
-        values.put(ProductContract.ProductEntry.COLUMN_PICTURE, picture);
+        values.put(ProductContract.ProductEntry.COLUMN_PICTURE_PATH, picture);
 
         if (selectedProductUri == null) {
             // Add a product.

--- a/app/src/main/java/com/davidread/clothescatalog/view/DetailActivity.java
+++ b/app/src/main/java/com/davidread/clothescatalog/view/DetailActivity.java
@@ -49,7 +49,6 @@ import com.google.android.material.snackbar.Snackbar;
 import com.google.android.material.textfield.TextInputEditText;
 import com.google.android.material.textfield.TextInputLayout;
 
-import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -114,6 +113,12 @@ public class DetailActivity extends AppCompatActivity implements
     private Uri selectedProductUri;
 
     /**
+     * Whether the loader has already done an initial load of data. Keeping track of this stops
+     * subsequent loads from occurring when this activity is navigated to and from.
+     */
+    private boolean isLoadDone;
+
+    /**
      * Contains background colors to apply onto a sample image for
      * {@link #showSampleImageInPhotoImageView(int)}.
      */
@@ -125,10 +130,10 @@ public class DetailActivity extends AppCompatActivity implements
     private int id;
 
     /**
-     * Contains the {@code byte[]} representation of the image corresponding with this product. If
-     * {@code null}, then this product has no picture.
+     * A path to the file containing the image corresponding with this product. If {@code null},
+     * then this product has no picture.
      */
-    private byte[] picture;
+    private String picturePath;
 
     /**
      * Launches an activity to the camera to capture an image for the product.
@@ -136,10 +141,10 @@ public class DetailActivity extends AppCompatActivity implements
     private ActivityResultLauncher<Uri> takePictureActivityResultLauncher;
 
     /**
-     * File containing the image captured by the camera in the activity started by
+     * File path to the image captured by the camera in the activity started by
      * {@link #takePictureActivityResultLauncher}.
      */
-    private File takePictureFile;
+    private String takePicturePath;
 
     /**
      * Launches an activity to pick an image for the product.
@@ -177,6 +182,8 @@ public class DetailActivity extends AppCompatActivity implements
 
         Intent intent = getIntent();
         selectedProductUri = intent.getData();
+
+        isLoadDone = false;
 
         sampleImageBackgroundColors = getResources().getIntArray(R.array.sample_image_backgrounds);
 
@@ -349,9 +356,8 @@ public class DetailActivity extends AppCompatActivity implements
      */
     @Override
     public void onLoadFinished(@NonNull Loader<Cursor> loader, Cursor data) {
-        boolean hasFirstRow = data.moveToFirst();
-        if (!hasFirstRow) {
-            // Cursor is empty.
+        if (isLoadDone || !data.moveToFirst()) {
+            // Cursor has already been loaded or Cursor is empty.
             return;
         }
 
@@ -365,7 +371,9 @@ public class DetailActivity extends AppCompatActivity implements
         int supplierEmailColumnIndex = data.getColumnIndex(
                 ProductContract.ProductEntry.COLUMN_SUPPLIER_EMAIL
         );
-        int pictureColumnIndex = data.getColumnIndex(ProductContract.ProductEntry.COLUMN_PICTURE_PATH);
+        int picturePathColumnIndex = data.getColumnIndex(
+                ProductContract.ProductEntry.COLUMN_PICTURE_PATH
+        );
 
         id = data.getInt(idColumnIndex);
         String name = data.getString(nameColumnIndex);
@@ -374,7 +382,7 @@ public class DetailActivity extends AppCompatActivity implements
         String supplier = data.getString(supplierColumnIndex);
         String supplierPhoneNumber = data.getString(supplierPhoneNumberColumnIndex);
         String supplierEmail = data.getString(supplierEmailColumnIndex);
-        picture = data.getBlob(pictureColumnIndex);
+        picturePath = data.getString(picturePathColumnIndex);
 
         nameTextInputEditText.setText(name);
         priceTextInputEditText.setText(price);
@@ -382,13 +390,15 @@ public class DetailActivity extends AppCompatActivity implements
         supplierTextInputEditText.setText(supplier);
         supplierPhoneNumberTextInputEditText.setText(supplierPhoneNumber);
         supplierEmailTextInputEditText.setText(supplierEmail);
-        if (picture == null) {
+        if (picturePath == null) {
             // Show sample image.
             showSampleImageInPhotoImageView(id);
         } else {
             // Show stored image.
-            showImageInPhotoImageView(picture);
+            showImageInPhotoImageView(picturePath);
         }
+
+        isLoadDone = true;
     }
 
     /**
@@ -405,7 +415,7 @@ public class DetailActivity extends AppCompatActivity implements
         supplierTextInputEditText.setText("");
         supplierPhoneNumberTextInputEditText.setText("");
         supplierEmailTextInputEditText.setText("");
-        picture = null;
+        picturePath = null;
         showSampleImageInPhotoImageView(id);
     }
 
@@ -471,15 +481,16 @@ public class DetailActivity extends AppCompatActivity implements
 
     /**
      * Invoked when the take new photo button is clicked. It launches an intent to the device's
-     * camera to take a photo. It puts the photo file in {@link #takePictureFile} and invokes
+     * camera to take a photo. It puts the photo file in {@link #takePicturePath} and invokes
      * {@link #onTakePictureActivityResult(boolean)} when done.
      */
     private void onTakeNewPhotoButtonClick() {
-        takePictureFile = createFile();
+        File file = createNewInternalFile();
+        takePicturePath = file.getAbsolutePath();
         Uri takePictureUri = FileProvider.getUriForFile(
                 this,
                 FILE_PROVIDER_AUTHORITY,
-                takePictureFile
+                file
         );
         takePictureActivityResultLauncher.launch(takePictureUri);
     }
@@ -489,7 +500,7 @@ public class DetailActivity extends AppCompatActivity implements
      * and shows the sample image in the UI.
      */
     private void onRemovePhotoButtonClick() {
-        picture = null;
+        picturePath = null;
         showSampleImageInPhotoImageView(id);
     }
 
@@ -657,7 +668,7 @@ public class DetailActivity extends AppCompatActivity implements
         values.put(ProductContract.ProductEntry.COLUMN_SUPPLIER, supplier);
         values.put(ProductContract.ProductEntry.COLUMN_SUPPLIER_PHONE_NUMBER, supplierPhoneNumber);
         values.put(ProductContract.ProductEntry.COLUMN_SUPPLIER_EMAIL, supplierEmail);
-        values.put(ProductContract.ProductEntry.COLUMN_PICTURE_PATH, picture);
+        values.put(ProductContract.ProductEntry.COLUMN_PICTURE_PATH, picturePath);
 
         if (selectedProductUri == null) {
             // Add a product.
@@ -698,8 +709,8 @@ public class DetailActivity extends AppCompatActivity implements
         if (!isSuccess) {
             return;
         }
-        picture = copyImageFileToByteArray(takePictureFile);
-        showImageInPhotoImageView(picture);
+        picturePath = takePicturePath;
+        showImageInPhotoImageView(picturePath);
     }
 
     /**
@@ -713,9 +724,9 @@ public class DetailActivity extends AppCompatActivity implements
         if (uri == null) {
             return;
         }
-        File file = copyImageUriToFile(uri);
-        picture = copyImageFileToByteArray(file);
-        showImageInPhotoImageView(picture);
+        File file = copyImageUriToNewInternalFile(uri);
+        picturePath = file.getAbsolutePath();
+        showImageInPhotoImageView(picturePath);
     }
 
     /**
@@ -725,6 +736,10 @@ public class DetailActivity extends AppCompatActivity implements
      */
     private void showSnackbar(@StringRes int resId) {
         Snackbar.make(detailCoordinatorLayout, resId, BaseTransientBottomBar.LENGTH_SHORT).show();
+    }
+
+    private void saveProduct() {
+
     }
 
     /**
@@ -841,7 +856,7 @@ public class DetailActivity extends AppCompatActivity implements
      */
     @SuppressLint("SimpleDateFormat")
     @NonNull
-    private File createFile() {
+    private File createNewInternalFile() {
         String timestamp = new SimpleDateFormat(FILE_TIMESTAMP_PATTERN).format(new Date());
         String fileName = String.format(FILE_NAME, timestamp);
         File fileDir = getFilesDir();
@@ -855,8 +870,8 @@ public class DetailActivity extends AppCompatActivity implements
      * @return A new {@link File} instance.
      */
     @NonNull
-    private File copyImageUriToFile(@NonNull Uri uri) {
-        File file = createFile();
+    private File copyImageUriToNewInternalFile(@NonNull Uri uri) {
+        File file = createNewInternalFile();
         try {
             InputStream inputStream = getContentResolver().openInputStream(uri);
             OutputStream outputStream = new FileOutputStream(file);
@@ -871,21 +886,6 @@ public class DetailActivity extends AppCompatActivity implements
             Log.e(TAG, e.toString());
         }
         return file;
-    }
-
-    /**
-     * Copies a file containing a picture to a {@code byte[]}.
-     *
-     * @param file File to copy from.
-     * @return {@code byte[]} equivalent of the picture.
-     */
-    @NonNull
-    private byte[] copyImageFileToByteArray(@NonNull File file) {
-        String filePath = file.getAbsolutePath();
-        Bitmap bitmap = BitmapFactory.decodeFile(filePath);
-        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-        bitmap.compress(Bitmap.CompressFormat.JPEG, 100, outputStream);
-        return outputStream.toByteArray();
     }
 
     /**
@@ -905,13 +905,13 @@ public class DetailActivity extends AppCompatActivity implements
     /**
      * Displays an image resource in the given image view.
      *
-     * @param array {@code byte[]} representation of the image to display.
+     * @param filePath Path to the file containing the image to display.
      */
-    private void showImageInPhotoImageView(@NonNull byte[] array) {
+    private void showImageInPhotoImageView(@NonNull String filePath) {
         photoImageView.setColorFilter(null);
         photoImageView.setBackgroundColor(getColor(android.R.color.transparent));
 
-        Bitmap bitmap = BitmapFactory.decodeByteArray(array, 0, array.length);
+        Bitmap bitmap = BitmapFactory.decodeFile(filePath);
         photoImageView.setImageBitmap(bitmap);
     }
 }

--- a/app/src/main/java/com/davidread/clothescatalog/view/InventoryActivity.java
+++ b/app/src/main/java/com/davidread/clothescatalog/view/InventoryActivity.java
@@ -313,7 +313,7 @@ public class InventoryActivity extends AppCompatActivity implements
                 ProductContract.ProductEntry.COLUMN_SUPPLIER_EMAIL,
                 DummyConstants.DUMMY_SUPPLIERS[supplierIndex][2]
         );
-        values.put(ProductContract.ProductEntry.COLUMN_PICTURE, (byte[]) null);
+        values.put(ProductContract.ProductEntry.COLUMN_PICTURE_PATH, (byte[]) null);
         return values;
     }
 


### PR DESCRIPTION
# Changelog
- Modify data storage in app such that a product picture will be stored in persistent storage via a file in the app's private directory. Then, a path to this internal file will be persisted in the product's entry in the product provider. This prevents pictures that are too big from being stored in the product provider, preventing ```SQLiteBlobTooBigException```s from occurring.
- Modify ```DetailActivity``` to only call ```onLoadFinished()``` once per activity creation. This prevents this function from overwriting the form with the product's old data when the user switches to and from this activity. This can occur when the user navigates to the camera activity to take a photo for the product picture.