### PR TITLE
Database and DetailActivity bugfix. Allow larger picture files to be persisted and prevent occasional overwrites of the DetailActivity form.

### DIFF
--- a/app/src/androidTest/java/com/davidread/clothescatalog/database/ProductProviderTest.java
+++ b/app/src/androidTest/java/com/davidread/clothescatalog/database/ProductProviderTest.java
@@ -54,7 +54,7 @@ public class ProductProviderTest {
         values.put(ProductContract.ProductEntry.COLUMN_PRICE, 1000);
         values.put(ProductContract.ProductEntry.COLUMN_QUANTITY, 10);
         values.put(ProductContract.ProductEntry.COLUMN_SUPPLIER, "Garment District");
-        values.put(ProductContract.ProductEntry.COLUMN_PICTURE, new byte[]{0, 1, 2, 3});
+        values.put(ProductContract.ProductEntry.COLUMN_PICTURE_PATH, new byte[]{0, 1, 2, 3});
 
         Uri insertUri = contentResolver.insert(ProductContract.ProductEntry.CONTENT_URI, values);
 
@@ -82,7 +82,7 @@ public class ProductProviderTest {
         values.put(ProductContract.ProductEntry.COLUMN_PRICE, -23);
         values.put(ProductContract.ProductEntry.COLUMN_QUANTITY, 55);
         values.put(ProductContract.ProductEntry.COLUMN_SUPPLIER, "Bed Bath and Beyond");
-        values.put(ProductContract.ProductEntry.COLUMN_PICTURE, new byte[]{4, 5, 6, 7});
+        values.put(ProductContract.ProductEntry.COLUMN_PICTURE_PATH, new byte[]{4, 5, 6, 7});
 
         Uri insertUri1 = contentResolver.insert(ProductContract.ProductEntry.CONTENT_URI, values1);
 
@@ -115,7 +115,7 @@ public class ProductProviderTest {
     public void update_ValidValues_ReturnsNotError() {
 
         ContentValues values = new ContentValues();
-        values.put(ProductContract.ProductEntry.COLUMN_PICTURE, new byte[]{8, 9, 10, 11});
+        values.put(ProductContract.ProductEntry.COLUMN_PICTURE_PATH, new byte[]{8, 9, 10, 11});
 
         int countRowsUpdated = contentResolver.update(
                 ProductContract.ProductEntry.CONTENT_URI,

--- a/app/src/main/java/com/davidread/clothescatalog/database/ProductContract.java
+++ b/app/src/main/java/com/davidread/clothescatalog/database/ProductContract.java
@@ -61,6 +61,6 @@ public final class ProductContract {
         public static final String COLUMN_SUPPLIER = "supplier";
         public static final String COLUMN_SUPPLIER_PHONE_NUMBER = "supplier_phone_number";
         public static final String COLUMN_SUPPLIER_EMAIL = "supplier_email";
-        public static final String COLUMN_PICTURE = "picture";
+        public static final String COLUMN_PICTURE_PATH = "picture_path";
     }
 }

--- a/app/src/main/java/com/davidread/clothescatalog/database/ProductDbHelper.java
+++ b/app/src/main/java/com/davidread/clothescatalog/database/ProductDbHelper.java
@@ -49,7 +49,7 @@ public class ProductDbHelper extends SQLiteOpenHelper {
                 + ProductContract.ProductEntry.COLUMN_SUPPLIER + " TEXT NOT NULL, "
                 + ProductContract.ProductEntry.COLUMN_SUPPLIER_PHONE_NUMBER + " TEXT NOT NULL, "
                 + ProductContract.ProductEntry.COLUMN_SUPPLIER_EMAIL + " TEXT NOT NULL, "
-                + ProductContract.ProductEntry.COLUMN_PICTURE + " BLOB);";
+                + ProductContract.ProductEntry.COLUMN_PICTURE_PATH + " TEXT);";
         db.execSQL(SQL_CREATE_PRODUCTS_TABLE);
     }
 

--- a/app/src/main/java/com/davidread/clothescatalog/database/ProductProvider.java
+++ b/app/src/main/java/com/davidread/clothescatalog/database/ProductProvider.java
@@ -366,10 +366,11 @@ public class ProductProvider extends ContentProvider {
             }
         }
 
-        // Picture column must be either null or a byte array.
-        if (values.containsKey(ProductContract.ProductEntry.COLUMN_PICTURE)) {
-            Object picture = values.get(ProductContract.ProductEntry.COLUMN_PICTURE);
-            if (picture != null && !(picture instanceof byte[])) {
+        // Picture path column must be null or a String.
+        if (values.containsKey(ProductContract.ProductEntry.COLUMN_PICTURE_PATH)) {
+            Object picturePath = values.get(ProductContract.ProductEntry.COLUMN_PICTURE_PATH);
+            if (picturePath != null
+                    && !(picturePath instanceof String)) {
                 return false;
             }
         }

--- a/app/src/main/java/com/davidread/clothescatalog/database/ProductProviderUtils.java
+++ b/app/src/main/java/com/davidread/clothescatalog/database/ProductProviderUtils.java
@@ -10,6 +10,10 @@ import java.text.DecimalFormat;
 import java.text.NumberFormat;
 import java.util.Locale;
 
+/**
+ * A class that provides util functions for accessing and modifying the price of a product in
+ * the product provider.
+ */
 public final class ProductProviderUtils {
 
     private ProductProviderUtils() {

--- a/app/src/main/java/com/davidread/clothescatalog/view/DetailActivity.java
+++ b/app/src/main/java/com/davidread/clothescatalog/view/DetailActivity.java
@@ -74,7 +74,7 @@ public class DetailActivity extends AppCompatActivity implements
      * Regular expressions that each text field should be matched with to be valid.
      */
     private static final String NAME_PATTERN = "^.{1,250}$";
-    private static final String PRICE_PATTERN = "^\\d{1,7}[.]\\d\\d$";
+    private static final String PRICE_PATTERN = "^\\d{1,7}[.]\\d{1,2}$";
     private static final String QUANTITY_PATTERN = "^\\d{1,9}$";
     private static final String SUPPLIER_PATTERN = "^.{1,250}$";
 

--- a/app/src/main/java/com/davidread/clothescatalog/view/DetailActivity.java
+++ b/app/src/main/java/com/davidread/clothescatalog/view/DetailActivity.java
@@ -513,7 +513,7 @@ public class DetailActivity extends AppCompatActivity implements
     private void onDecrementQuantityButtonClick() {
         Integer quantity = extractValueFromEditText(
                 quantityTextInputEditText,
-                QUANTITY_PATTERN,
+                null,
                 Integer.class
         );
         if (quantity == null || quantity <= 0) {
@@ -527,16 +527,16 @@ public class DetailActivity extends AppCompatActivity implements
 
     /**
      * Invoked when the increment button is clicked. It increments the quantity of the value in
-     * {@link #quantityTextInputEditText} by 1.
+     * {@link #quantityTextInputEditText} by 1 without letting the quantity fall above 999,999,999.
      */
     private void onIncrementQuantityButtonClick() {
         Integer quantity = extractValueFromEditText(
                 quantityTextInputEditText,
-                QUANTITY_PATTERN,
+                null,
                 Integer.class
         );
-        if (quantity == null) {
-            // No quantity was in the text field.
+        if (quantity == null || quantity >= 999999999) {
+            // No quantity was in the text field or quantity cannot be incremented any further.
             return;
         }
         quantity++;

--- a/app/src/main/java/com/davidread/clothescatalog/view/DetailActivity.java
+++ b/app/src/main/java/com/davidread/clothescatalog/view/DetailActivity.java
@@ -74,7 +74,7 @@ public class DetailActivity extends AppCompatActivity implements
      * Regular expressions that each text field should be matched with to be valid.
      */
     private static final String NAME_PATTERN = "^.{1,250}$";
-    private static final String PRICE_PATTERN = "^\\d{1,7}[.]\\d{1,2}$";
+    private static final String PRICE_PATTERN = "^\\d{1,7}(|[.]\\d{1,2})$";
     private static final String QUANTITY_PATTERN = "^\\d{1,9}$";
     private static final String SUPPLIER_PATTERN = "^.{1,250}$";
 

--- a/app/src/main/java/com/davidread/clothescatalog/view/InventoryActivity.java
+++ b/app/src/main/java/com/davidread/clothescatalog/view/InventoryActivity.java
@@ -313,7 +313,7 @@ public class InventoryActivity extends AppCompatActivity implements
                 ProductContract.ProductEntry.COLUMN_SUPPLIER_EMAIL,
                 DummyConstants.DUMMY_SUPPLIERS[supplierIndex][2]
         );
-        values.put(ProductContract.ProductEntry.COLUMN_PICTURE, (byte[]) null);
+        values.put(ProductContract.ProductEntry.COLUMN_PICTURE_PATH, (byte[]) null);
         return values;
     }
 


### PR DESCRIPTION
# Changelog
- Modify data storage in app such that a product picture will be stored in persistent storage via a file in the app's private directory. Then, a path to this internal file will be persisted in the product's entry in the product provider. This prevents pictures that are too big from being stored in the product provider, preventing ```SQLiteBlobTooBigException```s from occurring.
- Modify ```DetailActivity``` to only call ```onLoadFinished()``` once per activity creation. This prevents this function from overwriting the form with the product's old data when the user switches to and from this activity. This can occur when the user navigates to the camera activity to take a photo for the product picture.